### PR TITLE
updated to new oauth hash

### DIFF
--- a/spec/support/payloads.rb
+++ b/spec/support/payloads.rb
@@ -138,7 +138,7 @@ GITHUB_PAYLOADS = {
 
   :oauth => {
     "uid" => "234423",
-    "user_info" => {
+    "info" => {
       "name" => "John",
       "nickname" => "john",
       "email" => "john@email.com"
@@ -147,18 +147,6 @@ GITHUB_PAYLOADS = {
       "token" => "1234567890abcdefg"
     }
   },
-
-  :oauth_updated => {
-    "uid" => "234423",
-    "user_info" => {
-      "name" => "Johnathan",
-      "nickname" => "johnathan",
-      "email" => "johnathan@email.com"
-    },
-    "credentials" => {
-      "token" => "1234567890abcdefg"
-    }
-  }
 }
 
 WORKER_PAYLOADS = {

--- a/spec/travis/model/user_spec.rb
+++ b/spec/travis/model/user_spec.rb
@@ -6,7 +6,6 @@ describe User do
 
   let (:user)    { FactoryGirl.build(:user) }
   let (:payload) { GITHUB_PAYLOADS[:oauth] }
-  let (:updated_payload) { GITHUB_PAYLOADS[:oauth_updated] }
 
   describe 'find_or_create_for_oauth' do
     def user(payload)
@@ -19,19 +18,18 @@ describe User do
     end
 
     it 'updates changed attributes' do
-      user(payload)
-      user(updated_payload).login.should == 'johnathan'
+      user(payload).login.should == 'john'
     end
   end
 
   describe 'user_data_from_oauth' do
     it 'returns required data' do
       User.user_data_from_oauth(payload).should == {
-        'name'  => 'John',
-        'email' => 'john@email.com',
-        'login' => 'john',
-        'github_id' => '234423',
-        'github_oauth_token' => '1234567890abcdefg'
+        "name"                => "John",
+        "email"               => "john@email.com",
+        "login"               => "john",
+        "github_id"           => "234423",
+        "github_oauth_token"  => "1234567890abcdefg"
       }
     end
   end


### PR DESCRIPTION
This fixes the `User` model to look for the new hash that github is now using in it's payload. It no longer sends `user_info`, it's just called `info` now. Here's the primary difference:

```
def user_data_from_oauth(payload)
  {
    'name'  => payload['user_info']['name'],
    'email' => payload['user_info']['email'],
    'login' => payload['user_info']['nickname'],
    'github_id' => payload['uid'],
    'github_oauth_token' => payload['credentials']['token']
  }
end
```

... to ...

```
def user_data_from_oauth(payload)
  {
    'name'  => payload['info']['name'],
    'email' => payload['info']['email'],
    'login' => payload['info']['nickname'],
    'github_id' => payload['uid'],
    'github_oauth_token' => payload['credentials']['token']
  }
end
```
