### PR TITLE
Fixed an issue where not all repos were being shown on the profile page

### DIFF
--- a/lib/travis/github_api.rb
+++ b/lib/travis/github_api.rb
@@ -25,7 +25,7 @@ module Travis
       end
 
       def repositories_for_user(login)
-        Octokit.repositories(login)
+        Octokit.repositories(login, :page_size => 100)
       end
     end
   end


### PR DESCRIPTION
The profile page didn't have all repositories listed. This is because
Octokit will by default only show 30 items. If we specify a page size of
100 (this is the maximum size) we can get more repositories.
