### PR TITLE
Fix commit ref parsing for branches with '/' in the name.

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -110,7 +110,7 @@ module Github
     end
 
     def branch
-      (self['ref'] || '').split('/').last
+      (self['ref'] || '').gsub(/^refs\/heads\//, '')
     end
 
     def committed_at

--- a/spec/github_spec.rb
+++ b/spec/github_spec.rb
@@ -42,6 +42,18 @@ describe Github do
     }
   end
 
+  describe Github::Commit do
+    it 'should parse branch name from ref' do
+      commit = Github::Commit.new({ :ref => 'refs/heads/master' }, Github::Repository.new)
+      commit.branch.should == 'master'
+    end
+
+    it 'should parse branch name with slash from ref' do
+      commit = Github::Commit.new({ :ref => 'refs/heads/feature/cookies' }, Github::Repository.new)
+      commit.branch.should == 'feature/cookies'
+    end
+  end
+
   it 'build' do
     repository = Github::Repository.new(data['repository'])
     commit = Github::Commit.new(data['commits'].first.merge('ref' => 'refs/heads/master', 'compare_url' => data['compare']), repository)


### PR DESCRIPTION
Splitting ref by slashes and taking the last part doesn't work well when branch name itself contains slashes. For example, with such approach from ref `refs/heads/feature/foo` branch name is parsed as `foo` while it should be `feature/foo`.
