### PR TITLE
Fix mailer spec for 1.9.3

### DIFF
--- a/spec/travis/mailer/build_spec.rb
+++ b/spec/travis/mailer/build_spec.rb
@@ -21,6 +21,7 @@ describe Travis::Mailer::Build do
 
   before :each do
     Travis::Mailer.setup
+    I18n.reload!
     ActionMailer::Base.delivery_method = :test
   end
 


### PR DESCRIPTION
Mailer specs do not pass on MRI 1.9.3 without `force_encoding`.
