### PR TITLE
Hopefully fixes an AR deserialization issue

### DIFF
--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -127,8 +127,9 @@ class Build < ActiveRecord::Base
   # sometimes the config is not deserialized and is returned
   # as a string, this is a work around for now :(
   def config
-    deserialized = super
+    deserialized = self['config']
     if deserialized.is_a?(String)
+      logger.warn "Attribute config isn't YAML. Current serialized attributes: #{Build.serialized_attributes}"
       deserialized = YAML.load(deserialized)
     end
     deserialized

--- a/spec/travis/model/build_spec.rb
+++ b/spec/travis/model/build_spec.rb
@@ -107,7 +107,8 @@ describe Build do
 
       fit 'tries to deserialize the config itself if a String is returned' do
         build = Factory(:build)
-        build.expects(:read_attribute).with('config').returns("---\nfoo:\n  bar: bar")
+        build.stubs(:read_attribute).returns("---\n:foo:\n  :bar: bar")
+        Build.logger.expects(:warn)
         build.config[:foo][:bar].should == 'bar'
       end
     end


### PR DESCRIPTION
Errors in the hub happen sporadically where the Build.config attribute is not deserialized from YAML correctly. This is a fallback for now, it doesn't fix the root cause, just puts a bandaid over it.
