### PR TITLE
irc template and url shortener changes

### DIFF
--- a/lib/travis/model/url.rb
+++ b/lib/travis/model/url.rb
@@ -2,17 +2,21 @@ require 'active_record'
 
 class Url < ActiveRecord::Base
 
-  validates :url,
-    :presence => true,
-    :uniqueness => true
-  validates :code,
-    :presence => true,
-    :uniqueness => true
+  validates :url,  :presence => true, :uniqueness => true
+  validates :code, :presence => true, :uniqueness => true
 
   before_validation :set_code, :on => :create
 
+  def self.shorten(url)
+    find_or_create_by_url(url)
+  end
+
+  def short_url
+    [Travis.config.shorten_host, code].join('/')
+  end
 
   private
+
   def set_code
     self.code = [[Digest::MD5.hexdigest(url).to_i(13)].pack("N")].pack("m0").tr("+/", "-_").sub(/==\n?$/, '')
   end

--- a/spec/travis/model/url_spec.rb
+++ b/spec/travis/model/url_spec.rb
@@ -4,9 +4,29 @@ require 'support/active_record'
 describe Url do
   include Support::ActiveRecord
 
+  subject { Url.create(:url => "http://example.com") }
 
-  it "should set the code automatically" do
-    url = described_class.create :url => "http://example.com"
-    url.code.should_not be_nil
+  describe ".shorten" do
+    it "creates a new Url object if the url has not been shortened" do
+      expect { Url.shorten("http://example.com") }.to change(Url, :count).from(0).to(1)
+    end
+
+    it "retrieves a Url which has already been shortened" do
+      Url.shorten("http://example.com")
+      expect { Url.shorten("http://example.com") }.not_to change(Url, :count)
+    end
   end
+
+  describe "#code" do
+    it "sets the code automatically" do
+      subject.code.should_not be_nil
+    end
+  end
+
+  describe "#short_url" do
+    it "returns the full short url" do
+      subject.short_url.should match(%r(^http://trvs.io/\w{6}$))
+    end
+  end
+
 end


### PR DESCRIPTION
moves the url shortening related methods into Url and removes the need for
the url regex in the template.

one of the advantages of removing the regex is that if urls are in the commit
message they now won't be shortened.
