### PR TITLE
no need to select a reduced set of fields any more

### DIFF
--- a/lib/travis/model/job/test.rb
+++ b/lib/travis/model/job/test.rb
@@ -17,7 +17,7 @@ class Job
 
     class << self
       def append_log!(id, chars)
-        job = find(id, :select => [:id, :repository_id, :source_id, :source_type, :state, :config]) # is this still needed? we introduced this as an optimization when the log was still on the jobs table
+        job = find(id)
         job.append_log!(chars) unless job.finished?
       end
     end


### PR DESCRIPTION
we used this in order to not load the entire log when it was still on the jobs table. now that the log is on the artifact association we don't need this any more. it causes bugs or confusion once in a while so i'd like to kill it
