### PR TITLE
fix request creation for payloads that do not have a commit

### DIFF
--- a/lib/travis/model/request.rb
+++ b/lib/travis/model/request.rb
@@ -31,7 +31,7 @@ class Request < ActiveRecord::Base
     end
 
     def commit_for(payload, repository)
-      Commit.create!(payload.attributes[:commit].merge(:repository_id => repository.id))
+      Commit.create!(payload.attributes[:commit].merge(:repository_id => repository.id)) if payload.attributes[:commit]
     end
   end
 
@@ -40,7 +40,7 @@ class Request < ActiveRecord::Base
   belongs_to :repository
   has_many   :builds
 
-  validates :repository_id, :commit_id, :presence => true
+  validates :repository_id, :presence => true
 
   serialize :config
 

--- a/lib/travis/model/request/payload/github.rb
+++ b/lib/travis/model/request/payload/github.rb
@@ -11,7 +11,7 @@ class Request
       end
 
       def attributes
-        { :source => source, :payload => payload, :commit => last_commit.to_hash, :token => token }
+        { :source => source, :payload => payload, :commit => last_commit.try(:to_hash), :token => token }
       end
     end
   end

--- a/spec/travis/model/request_spec.rb
+++ b/spec/travis/model/request_spec.rb
@@ -21,6 +21,13 @@ describe Request do
       request.payload.should == payload
       request.token.should == 'token'
     end
+
+    it 'creates a request for a payload that does not contain a commit' do
+      payload = GITHUB_PAYLOADS['force-no-commit']
+      request = Request.create_from(payload, 'token')
+      request.payload.should == payload
+      request.token.should == 'token'
+    end
   end
 
   describe 'repository_for' do


### PR DESCRIPTION
we now always create a request for incoming pings. so requests are valid without a commit, too
