### PR TITLE
WIP add a metric for wait time from request create to build start

### DIFF
--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -40,6 +40,7 @@ class Build < ActiveRecord::Base
   autoload :Compat,        'travis/model/build/compat'
   autoload :Denormalize,   'travis/model/build/denormalize'
   autoload :Matrix,        'travis/model/build/matrix'
+  autoload :Metrics,       'travis/model/build/metrics'
   autoload :Messages,      'travis/model/build/messages'
   autoload :Notifications, 'travis/model/build/notifications'
   autoload :States,        'travis/model/build/states'

--- a/lib/travis/model/build/metrics.rb
+++ b/lib/travis/model/build/metrics.rb
@@ -1,0 +1,14 @@
+class Build
+  module Metrics
+    def start(data = {})
+      super
+      meter 'travis.builds.start.delay', started_at - request.created_at
+    end
+
+    private
+
+      def meter(name, time)
+        Metriks.timer(name).update(time)
+      end
+  end
+end

--- a/spec/travis/model/build/metrics_spec.rb
+++ b/spec/travis/model/build/metrics_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'core_ext/module/include'
+
+class BuildMetricsMock
+  include do
+    attr_accessor :state
+
+    def start(data = {})
+      self.state = :started
+    end
+
+    def started_at
+      Time.now
+    end
+
+    def request
+      stub('request', :created_at => Time.now - 60)
+    end
+  end
+
+  include Build::Metrics
+end
+
+describe Build::Metrics do
+  let(:build) { BuildMetricsMock.new }
+  let(:timer) { stub('meter', :update) }
+
+  before :each do
+    Metriks.stubs(:timer).returns(timer)
+  end
+
+  it 'measures on "travis.builds.start.delay"' do
+    Metriks.expects(:timer).with('travis.builds.start.delay').returns(timer)
+    build.start(:started_at => Time.now)
+  end
+
+  it 'measures the time it takes from creating the request until starting the build' do
+    timer.expects(:update).with(60)
+    build.start(:started_at => Time.now)
+  end
+end


### PR DESCRIPTION
@mattmatt can you take a look at these?

i looked at that metriks api (and some of the implementation) but i couldn't figure out how to add a timer that does not start at `Time.now` but some point in the past (i.e. our `request.created_at`).

might wanna ping @eric about this?
