### PR TITLE
Support IRC channels with more than one leading "#"

### DIFF
--- a/lib/travis/model/build/notifications.rb
+++ b/lib/travis/model/build/notifications.rb
@@ -73,7 +73,7 @@ class Build
     def irc_channels
       @irc_channels ||= notification_values(:irc, :channels).inject(Hash.new([])) do |servers, url|
         # TODO parsing irc urls should probably happen in the client class
-        server_and_port, channel = url.split('#')
+        server_and_port, channel = url.split('#', 2)
         server, port = server_and_port.split(':')
         servers[[server, port]] += [channel]
         servers

--- a/spec/travis/notifications_spec.rb
+++ b/spec/travis/notifications_spec.rb
@@ -6,7 +6,19 @@ describe Travis::Notifications do
   include Travis::Notifications
   include Support::ActiveRecord
 
-  let(:build)    { Factory(:build, :config => { 'notifications' => { 'campfire' => 'evome:apitoken@42' } }) }
+  let(:build) do
+    Factory(:build, :config => {
+      'notifications' => {
+        'campfire' => 'evome:apitoken@42',
+        'irc' => {
+          'channels' => [
+            'irc.freenode.net#####example'
+          ]
+        }
+      }
+    })
+  end
+
   describe "notifying of an event" do
     describe "campfire" do
       before do
@@ -41,6 +53,16 @@ describe Travis::Notifications do
         build.config[:notifications][:webhooks] = {:urls => targets}
         Travis::Notifications::Handler::Webhook.any_instance.expects(:notify)
         notify("build:finish")
+      end
+    end
+
+    describe "irc" do
+      before do
+        Travis.config.notifications = [:irc]
+      end
+
+      it "should handle channel names with several '#'s in front of it" do
+        build.irc_channels.should == {['irc.freenode.net', nil] => ['####example']}
       end
     end
   end


### PR DESCRIPTION
This should probably be moved into the IRC handler at some point, like
the TODO says, but this'll work for now.

The second argument to `String#split` limits how many sections the
string will be split into, so setting it to 2 will limit it to two
parts: The server/port and the channel. It'll still remove the first
"#", but I'm assuming that's added again somewhere else.

I also added a spec for this, do tell if I added it in the wrong place.

Fixes #52

/cc @joshk
