### PR TITLE
Remove the hard-coded value for a build result in the Pusher payloads

### DIFF
--- a/lib/travis/api/json/pusher/build/finished.rb
+++ b/lib/travis/api/json/pusher/build/finished.rb
@@ -11,7 +11,7 @@ module Travis
             def build_data
               {
                 'id' => build.id,
-                'result' => 0,
+                'result' => build.result,
                 'finished_at' => format_date(build.finished_at)
               }
             end


### PR DESCRIPTION
I found a hard-coded value in the Pusher payloads. I removed it. What else is there to say?

/cc @svenfuchs
