### PR TITLE
Add a database constraint to make sure repositories are unique

### DIFF
--- a/db/migrate/20120519234217_add_unique_constraint_to_repositories.rb
+++ b/db/migrate/20120519234217_add_unique_constraint_to_repositories.rb
@@ -1,0 +1,9 @@
+class AddUniqueConstraintToRepositories < ActiveRecord::Migration
+  def up
+    execute 'ALTER TABLE repositories ADD CONSTRAINT repositories_must_be_uniqueue UNIQUE (name, owner_name)'
+  end
+
+  def down
+    execute 'ALTER TABLE repositories DROP CONSTRAINT repositories_must_be_uniqueue'
+  end
+end


### PR DESCRIPTION
Started working on a fix for #39.

I'm not sure if this this correct, but I think it is.

@joshk also said that we should handle build requests "failing" because of this gracefully, so we don't lose the build request. If someone could point me to how to do that, please do.
