### PR TITLE
Make by_member only return admin repositories.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,4 +31,6 @@ group :test do
   gem 'database_cleaner', '~> 0.7.1'
   gem 'mocha',            '~> 0.10.0'
   gem 'webmock',          '~> 1.8.0'
+  gem 'guard'
+  gem 'guard-rspec'
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,24 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+guard 'rspec', :version => 2 do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec" }
+
+  # Rails example
+  watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/(.*)(\.erb|\.haml)$})                 { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
+  watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
+  watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
+  watch('config/routes.rb')                           { "spec/routing" }
+  watch('app/controllers/application_controller.rb')  { "spec/controllers" }
+  
+  # Capybara request specs
+  watch(%r{^app/views/(.+)/.*\.(erb|haml)$})          { |m| "spec/requests/#{m[1]}_spec.rb" }
+  
+  # Turnip features and steps
+  watch(%r{^spec/acceptance/(.+)\.feature$})
+  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$})   { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance' }
+end
+

--- a/lib/travis/model/repository.rb
+++ b/lib/travis/model/repository.rb
@@ -57,7 +57,7 @@ class Repository < ActiveRecord::Base
     end
 
     def by_member(login)
-      joins(:users).where(:users => { :login => login })
+      administratable.joins(:users).where(:users => { :login => login })
     end
 
     def by_slug(slug)

--- a/spec/travis/model/repository_spec.rb
+++ b/spec/travis/model/repository_spec.rb
@@ -79,6 +79,25 @@ describe Repository do
         Repository.search('fuchs\\').to_a.count.should == 2
       end
     end
+
+    describe "by_member" do
+      let(:user) { Factory(:user) }
+      let(:repository_admin) { Factory(:repository, :owner => user)}
+      let(:repository_non_admin) { Factory(:repository, :owner => user, :name => 'globalize')}
+
+      before do
+        Permission.create!(:user => user, :repository => repository_admin, :admin => true)
+        Permission.create!(:user => user, :repository => repository_non_admin, :admin => false)
+      end
+
+      it "should only return the administratable repositories" do
+        Repository.by_member('svenfuchs').should have(1).item
+      end
+
+      it "shouldn't return the non-administrator repositories" do
+        Repository.by_member('svenfuchs').first.should == repository_admin
+      end
+    end
   end
 
   describe 'source_url' do


### PR DESCRIPTION
This is a temporary fix until we've improved the synchronization to fully sync push/pull/admin permissions.
