### PR TITLE
Support new format of specifying env vars

### DIFF
--- a/lib/travis/model/build/matrix/config.rb
+++ b/lib/travis/model/build/matrix/config.rb
@@ -19,7 +19,7 @@ class Build
       def to_a
         @as_array ||= begin
           keys.inject([]) do |result, key|
-            values = config[key]
+            values = normalize_config_values(key, config[key])
             values = [values] unless values.is_a?(Array)
 
             if values
@@ -32,6 +32,33 @@ class Build
         end
       end
       alias to_ary to_a
+
+      def normalize_config_values(key, values)
+        method_name = "normalize_#{key}_values"
+        values = send(method_name, values) if respond_to?(method_name)
+        values
+      end
+
+      def normalize_env_values(values)
+        global = nil
+
+        if values.is_a?(Hash) && (values[:global] || values[:matrix])
+          global = values[:global]
+          values = values[:matrix]
+        end
+
+        if global
+          global = [global] unless global.is_a?(Array)
+        else
+          return values
+        end
+
+        values = [values] unless values.is_a?(Array)
+        values.map do |line|
+          line = [line] unless line.is_a?(Array)
+          line + global
+        end
+      end
 
       # TODO: I'm lazy and I don't want to change tests for now,
       #       it can be removed later, especially when some tests


### PR DESCRIPTION
Before this commit, the only way of setting up ENV variables was to use
env key in travis.yml, for example:

``` yaml
env:
  - FOO=bar
  - BAR=baz
```

All the elements are then expanded into matrix, so such env array will
result in 2 tests runs. With FOO=bar and then with BAR=baz ENV
variables. The problem with such approach is that in order to specify
ENV variables that are available globally, you need to add such vars for
each line, for example:

``` yaml
env:
  - FOO=bar SOME_TOKEN=abcdef
  - BAR=baz SOME_TOKEN=abcdef
```

New format helps in such situations by allowing to specify lines that go
into matrix and lines that will be available globally:

``` yaml
env:
  global:
    - SOME_TOKEN=abcdef
  matrix:
    - FOO=bar
    - BAR=baz
```
