### PR TITLE
extract tasks to travis-tasks

### DIFF
--- a/lib/travis/task.rb
+++ b/lib/travis/task.rb
@@ -1,6 +1,7 @@
 require 'faraday'
 require 'core_ext/hash/compact'
 require 'active_support/core_ext/string'
+require 'active_support/core_ext/hash/keys'
 
 module Travis
   class Task
@@ -35,7 +36,7 @@ module Travis
 
     def initialize(data, options = {})
       @data = data
-      @options = options
+      @options = options.symbolize_keys
     end
 
     def run


### PR DESCRIPTION
i `travis-tasks` is ready for finally being extracted from `travis-hub`

there's an error in the `github_commit_status` task (https://gist.github.com/19c29716f4a6e6684f38), but i believe we currently have it in production, too, right?

currently deploying this branch to staging will queue tasks to two amqp queues: `tasks` and `tasks.log`, which then will be picked up by `travis-tasks-staging` and processed

the `tasks` queue could possibly configured so that it runs way more than just one parallel task. the `tasks.log` queue could additionally be sharded by job ids.
