### PR TITLE
Add a config switch for excluding logs from webhook payloads

### DIFF
--- a/lib/travis/api/v1/webhook/build.rb
+++ b/lib/travis/api/v1/webhook/build.rb
@@ -5,13 +5,14 @@ module Travis
         class Build
           autoload :Finished, 'travis/api/v1/webhook/build/finished'
 
-          attr_reader :build, :commit, :request, :repository
+          attr_reader :build, :commit, :request, :repository, :options
 
           def initialize(build, options = {})
             @build = build
             @commit = build.commit
             @request = build.request
             @repository = build.repository
+            @options = options
           end
 
           private

--- a/lib/travis/api/v1/webhook/build/finished.rb
+++ b/lib/travis/api/v1/webhook/build/finished.rb
@@ -8,7 +8,7 @@ module Travis
 
             include Formats
 
-            def data(options = {})
+            def data
               {
                 'id' => build.id,
                 'repository' => repository_data,
@@ -31,7 +31,7 @@ module Travis
                 'author_email' => commit.author_email,
                 'committer_name' => commit.committer_name,
                 'committer_email' => commit.committer_email,
-                'matrix' => build.matrix.map { |job| Job.new(job).data(options) }
+                'matrix' => build.matrix.map { |job| Job.new(job, options).data }
               }
             end
 

--- a/lib/travis/api/v1/webhook/build/finished/job.rb
+++ b/lib/travis/api/v1/webhook/build/finished/job.rb
@@ -7,14 +7,15 @@ module Travis
             class Job
               include Formats
 
-              attr_reader :job, :commit
+              attr_reader :job, :commit, :options
 
-              def initialize(job)
+              def initialize(job, options = {})
                 @job = job
                 @commit = job.commit
+                @options = options
               end
 
-              def data(options = {})
+              def data
                 data = {
                   'id' => job.id,
                   'repository_id' => job.repository_id,
@@ -34,7 +35,7 @@ module Travis
                   'committer_name' => commit.committer_name,
                   'committer_email' => commit.committer_email
                 }
-                data['log'] = job.log.try(:content) || '' unless options[:bare]
+                data['log'] = job.log.try(:content) || '' if options[:include_log]
                 data['started_at'] = format_date(job.started_at) if job.started?
                 data['finished_at'] = format_date(job.finished_at) if job.finished?
                 data

--- a/lib/travis/event/config/webhook.rb
+++ b/lib/travis/event/config/webhook.rb
@@ -4,6 +4,10 @@ module Travis
   module Event
     class Config
       class Webhook < Config
+        def include_log?
+          with_fallbacks(:webhooks, :include_log, true)
+        end
+
         def send_on_start?
           !build.pull_request? && webhooks.present? && send_on_start_for?(:webhooks)
         end

--- a/lib/travis/event/handler/webhook.rb
+++ b/lib/travis/event/handler/webhook.rb
@@ -25,7 +25,12 @@ module Travis
         end
 
         def payload
-          @payload ||= Api.data(object, :for => 'webhook', :type => 'build/finished', :version => API_VERSION)
+          @payload ||= Api.data(object,
+            :for => 'webhook',
+            :type => 'build/finished',
+            :params => { :include_log => config.include_log? },
+            :version => API_VERSION
+          )
         end
 
         def token

--- a/spec/travis/api/v1/webhook/build/finished_spec.rb
+++ b/spec/travis/api/v1/webhook/build/finished_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe Travis::Api::V1::Webhook::Build::Finished do
   include Travis::Testing::Stubs, Support::Formats
 
-  let(:data)  { Travis::Api::V1::Webhook::Build::Finished.new(build).data }
+  let(:data)    { Travis::Api::V1::Webhook::Build::Finished.new(build, options).data }
+  let(:options) { { :include_log => true } }
 
   it 'data' do
     data.except('repository', 'matrix').should == {
@@ -39,28 +40,39 @@ describe Travis::Api::V1::Webhook::Build::Finished do
     }
   end
 
-  it 'matrix' do
-    data['matrix'].first.should == {
-      'id' => 1,
-      'repository_id' => 1,
-      'parent_id' => 1,
-      'number' => '2.1',
-      'state' => 'finished',
-      'started_at' => json_format_time(Time.now.utc - 1.minute),
-      'finished_at' => json_format_time(Time.now.utc),
-      'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
-      'status' => 0,
-      'result' => 0,
-      'commit' => '62aae5f70ceee39123ef',
-      'branch' => 'master',
-      'message' => 'the commit message',
-      'author_name' => 'Sven Fuchs',
-      'author_email' => 'svenfuchs@artweb-design.de',
-      'committer_name' => 'Sven Fuchs',
-      'committer_email' => 'svenfuchs@artweb-design.de',
-      'committed_at' => json_format_time(Time.now.utc - 1.hour),
-      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
-      'log' => 'the test log',
-    }
+  describe 'matrix' do
+    it 'payload' do
+      data['matrix'].first.except('log').should == {
+        'id' => 1,
+        'repository_id' => 1,
+        'parent_id' => 1,
+        'number' => '2.1',
+        'state' => 'finished',
+        'started_at' => json_format_time(Time.now.utc - 1.minute),
+        'finished_at' => json_format_time(Time.now.utc),
+        'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
+        'status' => 0,
+        'result' => 0,
+        'commit' => '62aae5f70ceee39123ef',
+        'branch' => 'master',
+        'message' => 'the commit message',
+        'author_name' => 'Sven Fuchs',
+        'author_email' => 'svenfuchs@artweb-design.de',
+        'committer_name' => 'Sven Fuchs',
+        'committer_email' => 'svenfuchs@artweb-design.de',
+        'committed_at' => json_format_time(Time.now.utc - 1.hour),
+        'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+      }
+    end
+
+    it 'given include_log is true' do
+      options.replace :include_log => true
+      data['matrix'].first['log'].should == 'the test log'
+    end
+
+    it 'given include_log is false' do
+      options.replace :include_log => false
+      data['matrix'].first['log'].should be_nil
+    end
   end
 end

--- a/spec/travis/event/config/webhook_spec.rb
+++ b/spec/travis/event/config/webhook_spec.rb
@@ -14,6 +14,34 @@ describe Travis::Event::Config::Webhook do
     it_behaves_like 'a build configuration'
   end
 
+  describe :include_log? do
+    # TODO default is to be deprecated and changed to false
+    it 'returns true by default (single url given)' do
+      build.stubs(:config => { :notifications => { :webhooks => 'http://domain.com' } })
+      config.include_log?.should be_true
+    end
+
+    it 'returns true by default (array of urls given)' do
+      build.stubs(:config => { :notifications => { :webhooks => ['http://domain.com'] } })
+      config.include_log?.should be_true
+    end
+
+    it 'returns true by default (hash given)' do
+      build.stubs(:config => { :notifications => { :webhooks => {} } })
+      config.include_log?.should be_true
+    end
+
+    it 'returns true if defined in the config' do
+      build.stubs(:config => { :notifications => { :webhooks => { :include_log => true } } })
+      config.include_log?.should be_true
+    end
+
+    it 'returns false if defined in the config' do
+      build.stubs(:config => { :notifications => { :webhooks => { :include_log => false } } })
+      config.include_log?.should be_false
+    end
+  end
+
   describe :webhooks do
     it 'returns an array of urls when given a string' do
       webhooks = 'http://evome.fr/notifications'


### PR DESCRIPTION
We need people to be able to opt out of sending logs for now. This pull request makes it possible to do that in .travis.yml like this:

``` yml
notifications:
  webhooks:
    include_logs: false
    urls: ...
```

The `include_logs` switch currently defaults to `true`.

We are also considering to later: 
- either deprecate the default and switch it to `false`
- or deprecate this whole thing simply remove logs from the payload entirely and instead add a link per job where interested users can access the logs

In any case this change should fix the immediate issue.
