### PR TITLE
Allowing for square brackets and other non-whitespace characters to be present in HipChat room names

### DIFF
--- a/lib/travis/addons/hipchat/task.rb
+++ b/lib/travis/addons/hipchat/task.rb
@@ -44,7 +44,7 @@ module Travis
           end
 
           def parse(target)
-            target =~ /^([\w]+)@([\w ]+)$/
+            target =~ /^([\w]+)@([\S ]+)$/
             ["https://api.hipchat.com/v1/rooms/message?format=json&auth_token=#{$1}", $2]
           end
 

--- a/spec/travis/addons/hipchat/task_spec.rb
+++ b/spec/travis/addons/hipchat/task_spec.rb
@@ -18,7 +18,7 @@ describe Travis::Addons::Hipchat::Task do
   end
 
   it "sends hipchat notifications to the given targets" do
-    targets = ['12345@room_1', '23456@room_2']
+    targets = ['12345@room_1', '23456@room_2', '34567@[Dev] room3']
     message = [
       'svenfuchs/minimal#2 (master - 62aae5f : Sven Fuchs): the build has passed',
       'Change view: https://github.com/svenfuchs/minimal/compare/master...develop',
@@ -27,6 +27,7 @@ describe Travis::Addons::Hipchat::Task do
 
     expect_hipchat('room_1', '12345', message)
     expect_hipchat('room_2', '23456', message)
+    expect_hipchat('[Dev] room3', '34567', message)
 
     run(targets)
     http.verify_stubbed_calls


### PR DESCRIPTION
Covering for the case where room names may have square brackets.
