### PR TITLE
Enable gh-pages testing if explicitly added to .travis.yml

### DIFF
--- a/lib/travis/model/request/approval.rb
+++ b/lib/travis/model/request/approval.rb
@@ -13,7 +13,7 @@ class Request
         !repository.private? &&
         !rails_fork? &&
         !skipped? &&
-        !github_pages?
+        (github_pages_explicitly_enabled? || !github_pages?)
     end
 
     def approved?
@@ -46,6 +46,13 @@ class Request
 
       def skipped?
         commit.message.to_s =~ /\[ci(?: |:)([\w ]*)\]/i && $1.downcase == 'skip'
+      end
+
+      def github_pages_explicitly_enabled?
+        request.config &&
+          request.config['branches'] &&
+          request.config['branches']['only'] &&
+          request.config['branches']['only'].grep(/gh[-_]pages/i)
       end
 
       def github_pages?

--- a/spec/travis/model/request/approval_spec.rb
+++ b/spec/travis/model/request/approval_spec.rb
@@ -34,6 +34,12 @@ describe Request::Approval do
       request.commit.stubs(:ref).returns('gh_pages')
       approval.should_not be_accepted
     end
+
+    it 'accepts a request that belongs to the github_pages branch and is explicitly set to build that branch' do
+      request.commit.stubs(:ref).returns('gh_pages')
+      request.stubs(:config).returns({'branches' => {'only' => ['gh_pages']}})
+      approval.should be_accepted
+    end
   end
 
   describe 'approved?' do


### PR DESCRIPTION
This was requested in travis-ci/travis-ci#476.

If you add this to your `.travis.yml` file, the `gh-pages` branch will be tested by Travis.

``` YAML
branches:
  only:
    - gh-pages
```

See the pull request mentioned above for rationale for this.
