### PR TITLE
Blacklist repositories

### DIFF
--- a/lib/travis/config.rb
+++ b/lib/travis/config.rb
@@ -106,7 +106,7 @@ module Travis
             :ssl           => {},
             :sponsors      => { :platinum => [], :gold => [], :workers => {} },
             :redis         => { :url => ENV['REDISTOGO_URL'] || 'redis://localhost:6379' },
-            :repository_filter => { :whitelist => [/^rails\/rails/], :blacklist => [/\/rails$/] }
+            :repository_filter => { :include => [/^rails\/rails/], :exclude => [/\/rails$/] }
 
     default :_access => [:key]
 

--- a/lib/travis/model/request/approval.rb
+++ b/lib/travis/model/request/approval.rb
@@ -11,7 +11,7 @@ class Request
     def accepted?
       commit.present? &&
         !repository.private? &&
-        (!blacklisted_repository? || whitelisted_repository?) &&
+        (!excluded_repository? || included_repository?) &&
         !skipped? &&
         !github_pages?
     end
@@ -27,8 +27,8 @@ class Request
     def message
       if !commit.present?
         'missing commit'
-      elsif blacklisted_repository?
-        'blacklisted repository'
+      elsif excluded_repository?
+        'excluded repository'
       elsif skipped?
         'skipped through commit message'
       elsif github_pages?
@@ -52,12 +52,12 @@ class Request
         commit.ref =~ /gh[-_]pages/i
       end
 
-      def whitelisted_repository?
-        Travis.config.repository_filter.whitelist.any? { |rule| repository.slug =~ rule }
+      def excluded_repository?
+        Travis.config.repository_filter.exclude.any? { |rule| repository.slug =~ rule }
       end
 
-      def blacklisted_repository?
-        Travis.config.repository_filter.blacklist.any? { |rule| repository.slug =~ rule }
+      def included_repository?
+        Travis.config.repository_filter.include.any? { |rule| repository.slug =~ rule }
       end
 
       def branch_approved?

--- a/spec/travis/model/request/approval_spec.rb
+++ b/spec/travis/model/request/approval_spec.rb
@@ -20,7 +20,7 @@ describe Request::Approval do
       approval.should_not be_accepted
     end
 
-    it 'does not accept a request that belongs to a blacklisted repository' do
+    it 'does not accept a request that belongs to an excluded repository' do
       request.repository.stubs(:slug).returns('svenfuchs/rails')
       approval.should_not be_accepted
     end
@@ -52,9 +52,9 @@ describe Request::Approval do
       approval.message.should == 'private repository'
     end
 
-    it 'returns "blacklisted repository" if the repository is a blacklisted repository' do
+    it 'returns "excluded repository" if the repository is an excluded repository' do
       request.repository.stubs(:slug).returns('svenfuchs/rails')
-      approval.message.should == 'blacklisted repository'
+      approval.message.should == 'excluded repository'
     end
 
     it 'returns "github pages branch" if the branch is a github pages branch' do
@@ -113,27 +113,27 @@ describe Request::Approval do
     end
   end
 
-  describe 'whitelisted_repository?' do
-    it 'returns true if the repository is whitelisted repository' do
+  describe 'included_repository?' do
+    it 'returns true if the repository is an included repository' do
       request.repository.stubs(:slug).returns 'rails/rails'
-      approval.send(:whitelisted_repository?).should be_true
+      approval.send(:included_repository?).should be_true
     end
 
-    it 'returns false if the repository is not whitelisted' do
+    it 'returns false if the repository is not included' do
       request.repository.stubs(:slug).returns 'josh/completeness-fu'
-      approval.send(:whitelisted_repository?).should be_false
+      approval.send(:included_repository?).should be_false
     end
   end
 
-  describe 'blacklisted_repository?' do
-    it 'returns true if the repository is a blacklisted repository' do
+  describe 'excluded_repository?' do
+    it 'returns true if the repository is an excluded repository' do
       request.repository.stubs(:slug).returns 'josh/rails'
-      approval.send(:blacklisted_repository?).should be_true
+      approval.send(:excluded_repository?).should be_true
     end
 
-    it 'returns false if the repository is not whitelisted' do
+    it 'returns false if the repository is not excluded' do
       request.repository.stubs(:slug).returns 'josh/completeness-fu'
-      approval.send(:blacklisted_repository?).should be_false
+      approval.send(:excluded_repository?).should be_false
     end
   end
 end


### PR DESCRIPTION
This is a port and refactoring of #7 with the addition of putting the repository blacklist and whitelist in `Travis.config`.
