### PR TITLE
Properly split chunks taking UTF-8 chars into account

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'gh',                 github: 'rkh/gh'
 gem 'newrelic_rpm',       '~> 3.4.2'
 gem 'hubble',             github: 'roidrage/hubble'
 gem 'addressable'
+gem 'coder',              github: 'rkh/coder'
 
 # TODO need to release the gem as soon i'm certain this change makes sense
 gem 'simple_states', github: 'svenfuchs/simple_states', branch: 'sf-set-state-early'

--- a/lib/travis.rb
+++ b/lib/travis.rb
@@ -44,6 +44,7 @@ module Travis
   autoload :Addons,       'travis/addons'
   autoload :Api,          'travis/api'
   autoload :Config,       'travis/config'
+  autoload :Chunkifier,   'travis/chunkifier'
   autoload :Enqueue,      'travis/enqueue'
   autoload :Event,        'travis/event'
   autoload :Features,     'travis/features'

--- a/lib/travis/addons/pusher/task.rb
+++ b/lib/travis/addons/pusher/task.rb
@@ -55,7 +55,7 @@ module Travis
               # split payload into 9kB chunks, the limit is 10 for entire request
               # body, 1kB should be enough for headers
               log = payload[:_log]
-              log.scan(/.{1,#{chunk_size}}/m).map { |part| payload.dup.merge(:_log => part) }
+              Chunkifier.new(log, chunk_size).map { |part| payload.dup.merge(:_log => part) }
             else
               [payload]
             end

--- a/lib/travis/chunkifier.rb
+++ b/lib/travis/chunkifier.rb
@@ -1,0 +1,60 @@
+require 'coder/cleaner/simple/encodings'
+
+module Travis
+  class Chunkifier < Struct.new(:content, :chunk_size)
+    include Enumerable
+    include Coder::Cleaner::Simple::Encodings::UTF_8
+
+    def each(&block)
+      parts.each(&block)
+    end
+
+    def parts
+      @parts ||= split
+    end
+
+    def split
+      chunks = []
+      carry  = []
+      content.bytes.each_slice(chunk_size) do |bytes|
+        if carry.length > 0
+          bytes.unshift *carry
+          carry = []
+        end
+
+        if bytes.length > chunk_size
+          carry = bytes.pop bytes.length - chunk_size
+        end
+
+        unless proper_end?(bytes)
+          carry.unshift *last_char(bytes)
+        end
+
+        chunks << to_utf8_string(bytes)
+      end
+
+      chunks << to_utf8_string(carry) if carry.length > 0
+
+      chunks
+    end
+
+    def to_utf8_string bytes
+      bytes.pack('C*').force_encoding('utf-8')
+    end
+
+    def proper_end?(bytes)
+      single_byte?(bytes.last, nil) || begin
+        i = bytes.length - 1
+        i-=1 while !multibyte_start?(bytes[i], nil)
+        first = bytes[i]
+        multibyte_size(first, nil) == bytes.length - i
+      end
+    end
+
+    def last_char(bytes)
+      last = []
+      last.unshift bytes.pop while bytes.length > 0 && !single_byte?(bytes.last, nil)
+      last
+    end
+  end
+end

--- a/spec/travis/addons/pusher/task_spec.rb
+++ b/spec/travis/addons/pusher/task_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 
 describe Travis::Addons::Pusher::Task do
@@ -20,10 +21,10 @@ describe Travis::Addons::Pusher::Task do
 
   it 'splits log messages into chunks, to not exceed the limit' do
     subject.stubs(:chunk_size => 3)
-    run('job:test:log', test, params: { _log: "01\n2345" })
+    run('job:test:log', test, params: { _log: "01\ną345" })
 
     channel.messages.length.should == 3
-    channel.messages.map { |message| message[1][:_log] }.join('').should == "01\n2345"
+    channel.messages.map { |message| message[1][:_log] }.join('').should == "01\ną345"
   end
 
   describe 'run' do

--- a/spec/travis/chunkifier_spec.rb
+++ b/spec/travis/chunkifier_spec.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+require 'spec_helper'
+
+module Travis
+  describe Chunkifier do
+    let(:chunk_size) { 3 }
+    let(:subject) { Chunkifier.new(content, chunk_size) }
+
+    context 'with newlines' do
+      let(:content) { "01\n2345" }
+
+      its(:parts) { should == ["01\n", "234", "5"] }
+    end
+
+    context 'with multibyte characters in the middle of the chunk' do
+      let(:content) { "ab𤭢" }
+      let(:chunk_size) { 4 }
+
+      its(:parts) { should == ["ab", "𤭢"] }
+    end
+
+    context 'with a start byte as a first character of a chunk' do
+      let(:content) { "abcd𤭢" }
+      let(:chunk_size) { 4 }
+
+      its(:parts) { should == ["abcd", "𤭢"] }
+    end
+
+    context 'with a lot of carrying' do
+      let(:content) { "ab𤭢𤭢𤭢𤭢" }
+      let(:chunk_size) { 4 }
+
+      its(:parts) { should == ["ab", "𤭢", "𤭢", "𤭢", "𤭢" ] }
+    end
+
+    context 'with mixed size chars' do
+      let(:content) { "ab𤭢ąćó" }
+      let(:chunk_size) { 4 }
+
+      its(:parts) { should == ["ab", "𤭢", "ąć", "ó" ] }
+    end
+  end
+end


### PR DESCRIPTION
This should fix pusher messages to actually be under **10kB** even with lots of UTF-8 chars.
