### PR TITLE
Fix gh-pages branch check

### DIFF
--- a/lib/travis/model/request/approval.rb
+++ b/lib/travis/model/request/approval.rb
@@ -12,8 +12,11 @@ class Request
       commit.present? &&
         !repository.private? &&
         (!excluded_repository? || included_repository?) &&
-        !skipped? &&
-        (github_pages_explicitly_enabled? || !github_pages?)
+        !skipped?
+    end
+
+    def branch_accepted?
+      github_pages_explicitly_enabled? || !github_pages?
     end
 
     def approved?
@@ -35,7 +38,7 @@ class Request
         'github pages branch'
       elsif request.config.blank?
         'missing config'
-      elsif !branch_approved?
+      elsif !branch_approved? || !branch_accepted?
         'branch not included or excluded'
       elsif repository.private?
         'private repository'

--- a/lib/travis/model/request/states.rb
+++ b/lib/travis/model/request/states.rb
@@ -21,7 +21,13 @@ class Request
         Travis.logger.warn("[request:configure] Request not configured: config not blank, config=#{config.inspect} commit=#{commit.try(:commit).inspect}")
       else
         self.config = fetch_config
-        Travis.logger.info("[request:configure] Request successfully configured commit=#{commit.commit.inspect}")
+
+        if branch_accepted?
+          Travis.logger.info("[request:configure] Request successfully configured commit=#{commit.commit.inspect}")
+        else
+          self.config = nil
+          Travis.logger.warn("[request:configure] Request not accepted: event_type=#{event_type.inspect} commit=#{commit.try(:commit).inspect} message=#{approval.message.inspect}")
+        end
       end
       save!
     end
@@ -42,7 +48,7 @@ class Request
 
     protected
 
-      delegate :accepted?, :approved?, :to => :approval
+      delegate :accepted?, :approved?, :branch_accepted?, :to => :approval
 
       def approval
         @approval ||= Approval.new(self)

--- a/spec/travis/model/request/approval_spec.rb
+++ b/spec/travis/model/request/approval_spec.rb
@@ -5,6 +5,19 @@ describe Request::Approval do
 
   let(:approval) { Request::Approval.new(request) }
 
+  describe 'branch_accepted?' do
+    it 'does not accept a request that belongs to the github_pages branch' do
+      request.commit.stubs(:ref).returns('gh_pages')
+      approval.branch_accepted?.should be_false
+    end
+
+    it 'accepts a request that belongs to the gh-pages branch if it\'s specified in branches:only' do
+      request.commit.stubs(:ref).returns('gh_pages')
+      request.config['branches'] = { 'only' => ['gh-pages'] }
+      approval.branch_accepted?.should be_true
+    end
+  end
+
   describe 'accepted?' do
     it 'accepts a request that has a commit, belongs to a public repository, is not skipped and does not belong to the github_pages branch and it is not a rails fork' do
       approval.should be_accepted
@@ -27,11 +40,6 @@ describe Request::Approval do
 
     it 'does not accept a request that is skipped (using the commit message)' do
       request.commit.stubs(:message).returns('update README [ci:skip]')
-      approval.should_not be_accepted
-    end
-
-    it 'does not accept a request that belongs to the github_pages branch' do
-      request.commit.stubs(:ref).returns('gh_pages')
       approval.should_not be_accepted
     end
 

--- a/spec/travis/model/request/states_spec.rb
+++ b/spec/travis/model/request/states_spec.rb
@@ -46,6 +46,20 @@ describe Request::States do
         request.start
         request.result.should == :accepted
       end
+
+      describe 'but rejected branch' do
+        before :each do
+          approval.stubs(:branch_accepted?).returns(false)
+        end
+
+        it 'does config, but resets it to nil' do
+          request.expects(:fetch_config).returns({})
+
+          request.start
+
+          request.config.should be_nil
+        end
+      end
     end
 
     describe 'with a rejected request' do


### PR DESCRIPTION
From commit description:

```
Travis::Request::Approval#accepted? method was called before
fetch_config was triggered and in the same time it depended on config
values. This commit fixes it, by checking if gh-pages branch should be
tested only after config is fetched.
```

I don't like this solution too much (splitting `accepted?` into two methods, then the need to discard config if gh-pages is not present, and also yet another if there), but I just wanted to make it work for now - Approval - Request coupling should be probably addressed later.

/cc @henrikhodne @svenfuchs @joshk 
