### PR TITLE
Log pusher errors when sending events

### DIFF
--- a/lib/travis/addons/pusher/task.rb
+++ b/lib/travis/addons/pusher/task.rb
@@ -46,7 +46,13 @@ module Travis
               # TODO: the second argument in meter can be removed when we're sure that apps
               #       using this have newest travis-support version
               Travis::Instrumentation.meter('travis.addons.pusher.task.messages', {})
-              Travis.pusher[channel].trigger(event, part)
+
+              begin
+                Travis.pusher[channel].trigger(event, part)
+              rescue ::Pusher::Error => e
+                Travis.logger.error("[addons:pusher] Could not send event due to Pusher::Error: #{e.message}, event=#{event}, payload: #{part.inspect}")
+                raise
+              end
             end
           end
 

--- a/spec/travis/addons/pusher/task_spec.rb
+++ b/spec/travis/addons/pusher/task_spec.rb
@@ -19,6 +19,16 @@ describe Travis::Addons::Pusher::Task do
     subject.new(payload, event: event, version: version).run
   end
 
+  it 'logs Pusher errors and reraises' do
+    channel.expects(:trigger).raises(Pusher::Error.new('message'))
+    payload = Travis::Api.data(test, for: 'pusher', type: 'job/started', version: 'v1').deep_symbolize_keys
+    Travis.logger.expects(:error).with("[addons:pusher] Could not send event due to Pusher::Error: message, event=job:started, payload: #{payload.inspect}")
+
+    expect {
+      run('job:test:started', test)
+    }.to raise_error(Pusher::Error)
+  end
+
   it 'splits log messages into chunks, to not exceed the limit in bytes' do
     subject.stubs(:chunk_size => 5)
     run('job:test:log', test, params: { _log: "0000\ną" })


### PR DESCRIPTION
We need this code to be able to see which messages are exceeding the limit of 10kB once Pusher enables the limit.
