### PR TITLE
Decrypt config[:addons]

### DIFF
--- a/lib/travis/model/job.rb
+++ b/lib/travis/model/job.rb
@@ -93,6 +93,7 @@ class Job < ActiveRecord::Base
 
   def obfuscated_config
     config.dup.tap do |config|
+      config.delete(:addons)
       next unless config[:env]
       obfuscated_env = process_env(config[:env]) { |env| obfuscate_env(env) }
       config[:env] = obfuscated_env ? obfuscated_env.join(' ') : nil

--- a/spec/travis/model/job_spec.rb
+++ b/spec/travis/model/job_spec.rb
@@ -122,6 +122,18 @@ describe Job do
       }
     end
 
+    it 'removes addons config' do
+      job = Job.new(repository: Factory(:repository))
+      config = { rvm: '1.8.7',
+                 addons: { sauce_connect: true },
+               }
+      job.config = config
+
+      job.obfuscated_config.should == {
+        rvm: '1.8.7',
+      }
+    end
+
     context 'when job is from a pull request' do
       let :job do
         job = Job.new(repository: Factory(:repository))


### PR DESCRIPTION
I added some decryption support to config[:addons]. This will remove all addons support on pull requests, which, depending on what addons we may add, may not be what we want. What do you think?

/cc @drogus
## Todo
- [x] obfuscate_config
