### PR TITLE
Add support for channel keys

### DIFF
--- a/lib/travis/addons/irc/task.rb
+++ b/lib/travis/addons/irc/task.rb
@@ -51,7 +51,7 @@ module Travis
           end
 
           def send_message(client, channel)
-            client.join(channel, try_config(:key) || nil) if join?
+            client.join(channel, try_config(:channel_key) || nil) if join?
             messages.each { |message| client.say("[travis-ci] #{message}", channel, notice?) }
             client.leave(channel) if join?
           end

--- a/spec/travis/addons/irc/task_spec.rb
+++ b/spec/travis/addons/irc/task_spec.rb
@@ -210,7 +210,7 @@ describe Travis::Addons::Irc::Task do
   end
 
   it 'allows setting a channel key' do
-    payload['build']['config']['notifications'] = { irc: { use_notice: true, key: 'pass' } }
+    payload['build']['config']['notifications'] = { irc: { use_notice: true, channel_key: 'pass' } }
 
     expect_irc 'irc.freenode.net', 1234, 'travis', [
       'NICK travis-ci',


### PR DESCRIPTION
The client had the option to specify a channel password, but the task didn't use it.

This adds `key:` as a parameter for the IRC notifications. Legit name?
