### PR TITLE
Add an API to retrieve recent builds

### DIFF
--- a/lib/travis/services/find_builds.rb
+++ b/lib/travis/services/find_builds.rb
@@ -35,6 +35,8 @@ module Travis
             else
               params[:after_number] ? builds.older_than(params[:after_number]) : builds.recent
             end
+          elsif params.nil? || params == {}
+            scope(:build).recent
           else
             scope(:build).none
           end

--- a/spec/travis/services/find_builds_spec.rb
+++ b/spec/travis/services/find_builds_spec.rb
@@ -15,6 +15,11 @@ describe Travis::Services::FindBuilds do
       service.run.should == [build]
     end
 
+    it 'finds recent builds when no repo given' do
+      @params = nil
+      service.run.should == [build]
+    end
+
     it 'finds builds older than the given number' do
       @params = { :repository_id => repo.id, :after_number => 2 }
       service.run.should == [build]


### PR DESCRIPTION
When included into travis-api, this makes `/builds` return the most recent builds instead of no builds.
