### PR TITLE
`notes_for` doesn't use format for now

### DIFF
--- a/lib/travis/addons/email/mailer/helpers.rb
+++ b/lib/travis/addons/email/mailer/helpers.rb
@@ -63,7 +63,7 @@ module Travis
             diff % ONE_MINUTE
           end
 
-          def notes_for(jobs, format)
+          def notes_for(jobs)
             tags_for(jobs).map do |tag|
               rule = rule_for(tag)
               rule.symbolize_keys.merge(jobs: numbers_for(jobs, tag)) if rule

--- a/lib/travis/addons/email/mailer/views/build/finished_email.html.erb
+++ b/lib/travis/addons/email/mailer/views/build/finished_email.html.erb
@@ -55,7 +55,7 @@
               <th style="text-align: right; padding-right: 16px;" align="right">Duration</th>
               <td><%= duration_in_words(@build.started_at, @build.finished_at) %></td>
             </tr>
-            <% unless (notes = notes_for(@jobs, 'html')).empty? %>
+            <% unless (notes = notes_for(@jobs)).empty? %>
               <tr>
                 <th style="text-align: right; padding-right: 16px;" align="right">Notes</th>
                 <td>

--- a/lib/travis/addons/email/mailer/views/build/finished_email.html.erb.src
+++ b/lib/travis/addons/email/mailer/views/build/finished_email.html.erb.src
@@ -55,7 +55,7 @@
               <th>Duration</th>
               <td><%= duration_in_words(@build.started_at, @build.finished_at) %></td>
             </tr>
-            <% unless (notes = notes_for(@jobs, 'html')).empty? %>
+            <% unless (notes = notes_for(@jobs)).empty? %>
               <tr>
                 <th>Notes</th>
                 <td>

--- a/lib/travis/addons/email/mailer/views/build/finished_email.text.erb
+++ b/lib/travis/addons/email/mailer/views/build/finished_email.text.erb
@@ -8,7 +8,7 @@ Duration: <%= duration_in_words(@build.started_at, @build.finished_at) %>
 Commit: <%= @commit.sha[0..6] %> (<%= @commit.branch %>)
 Author: <%= @commit.author_name %>
 Message: <%= @commit.message %>
-<% unless (notes = notes_for(@jobs, 'html')).empty? %>
+<% unless (notes = notes_for(@jobs)).empty? %>
 
 Notes:
 <% notes.each do |note| %>


### PR DESCRIPTION
`notes_for` doesn't use format for now
