### PR TITLE
Update Github status on build:created and build:queued

### DIFF
--- a/lib/travis/addons/github_status/event_handler.rb
+++ b/lib/travis/addons/github_status/event_handler.rb
@@ -6,7 +6,7 @@ module Travis
       # belongs to.
       class EventHandler < Event::Handler
         API_VERSION = 'v2'
-        EVENTS = /build:(started|finished)/
+        EVENTS = /build:(created|queued|started|finished)/
 
         def handle?
           token.present?

--- a/spec/travis/addons/github_status/event_handler_spec.rb
+++ b/spec/travis/addons/github_status/event_handler_spec.rb
@@ -15,6 +15,16 @@ describe Travis::Addons::GithubStatus::EventHandler do
       Travis::Api.stubs(:data).returns(stub('data'))
     end
 
+    it 'build:created notifies' do
+      handler.expects(:notify)
+      Travis::Event.dispatch('build:started', build)
+    end
+
+    it 'build:queued notifies' do
+      handler.expects(:notify)
+      Travis::Event.dispatch('build:queued', build)
+    end
+
     it 'build:started notifies' do
       handler.expects(:notify)
       Travis::Event.dispatch('build:started', build)


### PR DESCRIPTION
The github_status addon is setup to update to build status on Github for all of the different build states. However, the EVENTS regexp is not matching the `build:created` and `build:queued` events. This is causing the build status on Github not to be updated until the build has started.
