### PR TITLE
Adding support for basic auth in webhook URLs

### DIFF
--- a/lib/travis/addons/webhook/task.rb
+++ b/lib/travis/addons/webhook/task.rb
@@ -18,7 +18,15 @@ module Travis
           def send_webhook(target)
             response = http.post(target) do |req|
               req.body = { payload: payload.except(:params).to_json }
-              req.headers['Authorization'] = authorization
+              uri = URI(target)
+              if uri.user && uri.password
+                req.headers['Authorization'] =
+                  Faraday::Request::BasicAuthentication.header(
+                    URI.unescape(uri.user), URI.unescape(uri.password)
+                  )
+              else
+                req.headers['Authorization'] = authorization
+              end
             end
             response.success? ? log_success(response) : log_error(response)
           end


### PR DESCRIPTION
which takes precedence over the custom Authorization header made from the SHA256 hash of the repo slug + token.

This parsing is automatic when the Faraday builder is constructed with a `url` arg or a `Faraday::Connection` is initialized directly with a `:url` arg.  Since the Faraday builder is cached in `@http`, it looks like we instead have to parse and unescape the basic auth params directly.  If a more invasive redesign is desirable that takes advantage of Faraday's built-in basic auth support, I'll gladly do that instead :smile_cat: 
