### PR TITLE
Raise error when we don't have repository data in the payload

### DIFF
--- a/lib/travis/requests/services/receive/pull_request.rb
+++ b/lib/travis/requests/services/receive/pull_request.rb
@@ -18,6 +18,12 @@ module Travis
             end
           end
 
+          def validate!
+            if event['repository'].nil?
+              raise PayloadValidationError, "Repository data is not present in payload"
+            end
+          end
+
           def disabled?
             Travis::Features.feature_deactivated?(:pull_requests)
           end

--- a/lib/travis/requests/services/receive/push.rb
+++ b/lib/travis/requests/services/receive/push.rb
@@ -13,6 +13,12 @@ module Travis
             true
           end
 
+          def validate!
+            if event['repository'].nil?
+              raise PayloadValidationError, "Repository data is not present in payload"
+            end
+          end
+
           def repository
             @repository ||= {
               :name        => event['repository']['name'],

--- a/spec/travis/requests/services/receive_spec.rb
+++ b/spec/travis/requests/services/receive_spec.rb
@@ -16,6 +16,28 @@ describe Travis::Requests::Services::Receive do
     Request.any_instance.stubs(:start)
   end
 
+  describe 'without a repository data' do
+    before { payload['repository'] = nil }
+
+    context 'a push' do
+      let(:params) { { :event_type => 'push', :github_guid => 'abc123', :payload => payload } }
+
+      it 'raises validation error' do
+        message = "Repository data is not present in payload, github-guid=abc123, event-type=push"
+        expect { request }.to raise_error Travis::Requests::Services::Receive::PayloadValidationError, message
+      end
+    end
+
+    context 'a pull request' do
+      let(:params) { { :event_type => 'pull_request', :github_guid => 'abc123', :payload => payload } }
+
+      it 'raises validation error' do
+        message = "Repository data is not present in payload, github-guid=abc123, event-type=pull_request"
+        expect { request }.to raise_error Travis::Requests::Services::Receive::PayloadValidationError, message
+      end
+    end
+  end
+
   shared_examples_for 'creates a request and repository' do
     it 'creates a request for the given payload' do
       expect { request }.to change(Request, :count).by(1)


### PR DESCRIPTION
From commit message:

```
We got some payload with missing repository data recently and we're not
sure yet what went wrong. @github suggested to log delivery guid and
event type for such request, so we can get more information about it.

This commit raises an error with delivery guid and event type
when repository data is missing
```

One thing that came to my mind just now is: do we log errors from sidekiq jobs?
