### PR TITLE
Send amqp messages to workers after canceling the build.

### DIFF
--- a/spec/travis/services/cancel_build_spec.rb
+++ b/spec/travis/services/cancel_build_spec.rb
@@ -22,6 +22,11 @@ describe Travis::Services::CancelBuild do
       job.stubs(:cancelable?).returns(true)
       service.stubs(:authorized?).returns(true)
 
+      publisher = mock('publisher')
+      service.stubs(:publisher).returns(publisher)
+      publisher.expects(:publish).with(type: 'cancel_job', job_id: job.id)
+      publisher.expects(:publish).with(type: 'cancel_job', job_id: passed_job.id)
+
       expect {
         expect {
           service.run


### PR DESCRIPTION
From commit message:

```
When a build was cancelled we were not sending cancel messages to
workers, which means that while the job was set into canceled state, a
worker was still busy running the build.
```

This is the fix for travis-ci/travis-ci#1507
