### PR TITLE
notifications: Add build_id as a template variable

### DIFF
--- a/lib/travis/addons/util/template.rb
+++ b/lib/travis/addons/util/template.rb
@@ -20,6 +20,7 @@ module Travis
           @args ||= {
             repository:     data[:repository][:slug],
             build_number:   data[:build][:number].to_s,
+            build_id:       data[:build][:id].to_s,
             branch:         data[:commit][:branch],
             commit:         data[:commit][:sha][0..6],
             author:         data[:commit][:author_name],

--- a/spec/travis/addons/util/template_spec.rb
+++ b/spec/travis/addons/util/template_spec.rb
@@ -3,7 +3,18 @@ require 'spec_helper'
 describe Travis::Addons::Util::Template do
   include Travis::Testing::Stubs
 
-  VAR_NAMES = %w(repository build_number branch commit author message compare_url build_url result)
+  VAR_NAMES = %w(
+    repository
+    build_number
+    build_id
+    branch
+    commit
+    author
+    message
+    compare_url
+    build_url
+    result
+  )
   TEMPLATE  = VAR_NAMES.map { |name| "#{name}=%{#{name}}" }.join(' ')
 
   let(:data)     { Travis::Api.data(build, for: 'event', version: 'v0') }
@@ -18,6 +29,10 @@ describe Travis::Addons::Util::Template do
 
     it 'replaces the build_number' do
       result.should =~ /build_number=#{build.number}/
+    end
+
+    it "replaces the build_id" do
+      result.should =~ /build_id=1/
     end
 
     it 'replaces the branch' do


### PR DESCRIPTION
Closes travis-ci/travis-ci#1333.

I thought about adding job_id, but that doesn't make too much sense as notifications are per-build, not per-job.
