### PR TITLE
Don't build tag pushes

### DIFF
--- a/lib/travis/requests/services/receive/push.rb
+++ b/lib/travis/requests/services/receive/push.rb
@@ -10,7 +10,11 @@ module Travis
           end
 
           def accept?
-            true
+            !tag_push?
+          end
+
+          def tag_push?
+            event['ref'] =~ /^refs\/tags\/.*/
           end
 
           def validate!

--- a/spec/travis/requests/services/receive/push_spec.rb
+++ b/spec/travis/requests/services/receive/push_spec.rb
@@ -18,6 +18,13 @@ describe Travis::Requests::Services::Receive::Push do
     end
   end
 
+  describe 'accept?' do
+    it 'rejects tags pushes' do
+      payload.event.data['ref'] = 'refs/tags/deploy.2013.02.03'
+      payload.accept?.should be_false
+    end
+  end
+
   describe 'owner' do
     it 'returns all attributes required for an Owner' do
       payload.owner.should == {


### PR DESCRIPTION
Recently after changes on how we parse payload on pushes form github, we
started building tag pushes. Ultimately it's something we could do,
but right now tags are interpreted as branches, which is wrong anyway.
I'm disabling building tag pushes for now, until we can handle it
properly.
