### PR TITLE
Allow to test PR on synchronize

### DIFF
--- a/lib/travis/features.rb
+++ b/lib/travis/features.rb
@@ -40,15 +40,15 @@ module Travis
     end
 
     def activate_repository(feature, repository)
-      redis.sadd(repository_key(feature), repository.id)
+      redis.sadd(repository_key(feature), repository_identifier(repository))
     end
 
     def deactivate_repository(feature, repository)
-      redis.srem(repository_key(feature), repository.id)
+      redis.srem(repository_key(feature), repository_identifier(repository))
     end
 
     def repository_active?(feature, repository)
-      redis.sismember(repository_key(feature), repository.id)
+      redis.sismember(repository_key(feature), repository_identifier(repository))
     end
 
     def user_active?(feature, user)
@@ -102,6 +102,19 @@ module Travis
     extend self
 
     private
+
+    # Allow to identify repository by both slug and id.
+    # This may be useful when we don't want to fetch the
+    # repository record and slug is enough to identify it.
+    def repository_identifier(repository)
+      if repository.is_a?(Hash)
+        repository[:slug] || repository[:id]
+      elsif repository.respond_to?(:id)
+        repository = reppository.id
+      else
+        repository = repository.to_i
+      end
+    end
 
     def key(name)
       "feature:#{name}"

--- a/lib/travis/requests/services/receive/pull_request.rb
+++ b/lib/travis/requests/services/receive/pull_request.rb
@@ -13,7 +13,12 @@ module Travis
             return false if disabled?
             case action
             when :opened, :reopened then !!merge_commit
-            when :synchronize       then head_change?
+            when :synchronize       then
+              if Travis::Features.repository_active?(:test_pull_request_on_synchronize, slug: repository_slug)
+                !!merge_commit
+              else
+                head_change?
+              end
             else false
             end
           end
@@ -30,6 +35,10 @@ module Travis
 
           def head_change?
             head_commit && ::Request.last_by_head_commit(head_commit['sha']).nil?
+          end
+
+          def repository_slug
+            "#{repository[:owner_name]}/#{repository[:name]}"
           end
 
           def repository

--- a/spec/travis/requests/services/receive/pull_request_spec.rb
+++ b/spec/travis/requests/services/receive/pull_request_spec.rb
@@ -45,6 +45,13 @@ describe Travis::Requests::Services::Receive::PullRequest do
         payload.event.data['action'] = 'synchronize'
       end
 
+      it 'returns true even if head did not chante when repo is enabled to test on syncrhonize' do
+        payload.event.data['repository']['name'] = 'foo'
+        Travis::Features.activate_repository(:test_pull_request_on_synchronize, slug: 'travis-repos/foo')
+        Request.stubs(:last_by_head_commit).returns(last)
+        payload.accept?.should be_true
+      end
+
       it 'returns true if head has changed' do
         Request.stubs(:last_by_head_commit).returns(nil)
         payload.accept?.should be_true


### PR DESCRIPTION
From commit message:

```
When new commit is pushed to a target branch, github sends us
synchronize event. We haven't tested this commit, unless head was
changed, but it is a valid use case - when master changes, PR may no
longer pass, so it's good to retest it.

This commit allows to enable such a behavior for a specific repository
slug.
```

/cc @rkh
