### PR TITLE
Add more metrics to enqueue service

### DIFF
--- a/lib/travis/enqueue/services/enqueue_jobs.rb
+++ b/lib/travis/enqueue/services/enqueue_jobs.rb
@@ -67,7 +67,7 @@ module Travis
 
           def jobs
             Metriks.timer('enqueue.fetch_jobs').time do
-              Job.includes(:owner).queueable
+              Job.includes(:owner).queueable.all
             end
           end
 

--- a/spec/travis/enqueue/services/enqueue_jobs_spec.rb
+++ b/spec/travis/enqueue/services/enqueue_jobs_spec.rb
@@ -35,7 +35,9 @@ describe Travis::Enqueue::Services::EnqueueJobs do
     let(:test)      { stub_test(state: :created, enqueue: nil) }
 
     before :each do
-      Job.stubs(:queueable).returns([test])
+      scope = stub('scope')
+      scope.stubs(:all).returns([test])
+      Job.stubs(:queueable).returns(scope)
       service.stubs(:publisher).returns(publisher)
     end
 


### PR DESCRIPTION
More metrics giving us insight into enqueue, specifically the time for different parts of the process.
