### PR TITLE
Config should raise an error if both file and env configs are available

### DIFF
--- a/lib/travis/config.rb
+++ b/lib/travis/config.rb
@@ -118,7 +118,14 @@ module Travis
     default :_access => [:key]
 
     def initialize(data = nil, *args)
-      data = self.class.normalize(data || self.class.load_env || self.class.load_file || {})
+      env_config  = self.class.load_env
+      file_config = self.class.load_file
+
+      if env_config && file_config
+        raise "Both ENV config and file config detected, this is not probably what you want, stopping"
+      end
+
+      data = self.class.normalize(data || env_config || file_config || {})
       super
     end
 

--- a/spec/travis/config_spec.rb
+++ b/spec/travis/config_spec.rb
@@ -104,6 +104,17 @@ describe Travis::Config do
     end
   end
 
+  describe 'with both file and env config' do
+    before(:each) do
+      Travis::Config.stubs(:load_file).returns({})
+      Travis::Config.stubs(:load_env).returns({})
+    end
+
+    it 'should throw an error' do
+      lambda { config.pusher.key }.should raise_error /Both ENV config and file config detected/
+    end
+  end
+
   describe 'the example config file' do
     let(:data)    { {} }
     before(:each) { Travis::Config.stubs(:load_file).returns(data) }


### PR DESCRIPTION
We use file configs for some apps and ENV config for the others. When
both configs are available (for example because someone accidentally set
an ENV config where file config is already set), Travis.config will
silently prefer ENV over file config.

I have tested this on staging and it raises on such situation properly.
