### PR TITLE
Allow to cancel on pull permission

### DIFF
--- a/lib/travis/services/cancel_build.rb
+++ b/lib/travis/services/cancel_build.rb
@@ -49,7 +49,7 @@ module Travis
       end
 
       def authorized?
-        current_user.permission?(:push, :repository_id => build.repository_id)
+        current_user.permission?(:pull, :repository_id => build.repository_id)
       end
 
       def build

--- a/lib/travis/services/cancel_job.rb
+++ b/lib/travis/services/cancel_job.rb
@@ -38,7 +38,7 @@ module Travis
       end
 
       def authorized?
-        current_user.permission?(:push, :repository_id => job.repository_id)
+        current_user.permission?(:pull, :repository_id => job.repository_id)
       end
 
       def job

--- a/spec/travis/services/cancel_build_spec.rb
+++ b/spec/travis/services/cancel_build_spec.rb
@@ -45,8 +45,8 @@ describe Travis::Services::CancelBuild do
       }.to_not change { build.reload.state }
     end
 
-    it 'should not be able to cancel job if user does not have push permission' do
-      user.permissions.create(repository_id: repo.id, push: false)
+    it 'should not be able to cancel job if user does not have any permissions' do
+      user.permissions.destroy_all
 
       service.can_cancel?.should be_false
     end

--- a/spec/travis/services/cancel_job_spec.rb
+++ b/spec/travis/services/cancel_job_spec.rb
@@ -34,8 +34,8 @@ describe Travis::Services::CancelJob do
       }.to_not change { job.state }
     end
 
-    it 'should not be able to cancel job if user does not have push permission' do
-      user.permissions.create(repository_id: repo.id, push: false)
+    it 'should not be able to cancel job if user does not have pull permission' do
+      user.permissions.destroy_all
 
       service.can_cancel?.should be_false
     end


### PR DESCRIPTION
This change allows to cancel build or job while having only pull permission.

This needs deploying to API only, as only API uses cancel service. After enabling it in the API, travis-web also needs to be updated on org and on pro: travis-ci/travis-web#220
