### PR TITLE
Don't consider pull request builds as being on default branch

### DIFF
--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -252,7 +252,7 @@ class Build < Travis::Model
   end
 
   def on_default_branch?
-    branch == repository.default_branch
+    branch == repository.default_branch && !pull_request?
   end
 
   private

--- a/lib/travis/testing/factories.rb
+++ b/lib/travis/testing/factories.rb
@@ -60,6 +60,7 @@ FactoryGirl.define do
     last_build_started_at { Time.now.utc }
     last_build_finished_at { Time.now.utc }
     sequence(:github_id) {|n| n }
+    default_branch 'master'
   end
 
   factory :minimal, :parent => :repository do

--- a/spec/travis/model/build_spec.rb
+++ b/spec/travis/model/build_spec.rb
@@ -467,5 +467,47 @@ describe Build do
         build.reset
       end
     end
+
+    describe '#on_default_branch?' do
+      let(:repository) { Factory(:repository) }
+      let(:build) { Factory(:build, repository: repository) }
+
+      context 'when branch is the repository\'s default branch' do
+        before do
+          build.branch = repository.default_branch
+        end
+
+        context 'and build is not from a pull request' do
+          before do
+            build.event_type = 'push'
+          end
+
+          it 'returns true' do
+            build.on_default_branch?.should be_true
+          end
+        end
+
+        context 'and build is from a pull request' do
+          before do
+            build.event_type = 'pull_request'
+          end
+
+          it 'returns false' do
+            build.on_default_branch?.should be_false
+          end
+        end
+      end
+
+      context 'when branch is not the repository\'s default branch' do
+        before do
+          build.branch = 'foobarbaz'
+          build.event_type = 'push'
+        end
+
+        it 'returns false' do
+          build.on_default_branch?.should be_false
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This affects the current default e-mail policy (introduces with #291), which will email all members of a repository for builds on a default branch. With this change, pull request builds will not be considered 'default branch' builds.
