### PR TITLE
Restrict def email notification to committer and author

### DIFF
--- a/lib/travis/addons/email/event_handler.rb
+++ b/lib/travis/addons/email/event_handler.rb
@@ -39,13 +39,10 @@ module Travis
 
           def default_recipients
             recipients = object.repository.users.map(&:email)
-            unless object.on_default_branch?
-              recipients.select! do |r|
-                r == object.commit.author_email or
-                r == object.commit.committer_email
-              end
+            recipients.keep_if do |r|
+              r == object.commit.author_email or
+              r == object.commit.committer_email
             end
-            recipients
           end
 
           Instruments::EventHandler.attach_to(self)


### PR DESCRIPTION
Regardless of the branch, email only the committer and author of the
commit.
See
https://github.com/travis-ci/travis-ci/issues/488#issuecomment-29527429
and ensuing discussion on the rationale.

Comments welcome.
