### PR TITLE
Raise an error when updating the GitHub status fails.

### DIFF
--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -34,7 +34,9 @@ module Travis
               GH.post(url, :state => state, :description => description, :target_url => target_url)
             end
           rescue GH::Error => e
-            error "Could not update the PR status on #{GH.api_host + url} (#{e.message})."
+            message = "Could not update the PR status on #{GH.api_host + url} (#{e.message})."
+            error message
+            raise message
           end
 
           def target_url

--- a/spec/travis/addons/github_status/task_spec.rb
+++ b/spec/travis/addons/github_status/task_spec.rb
@@ -55,7 +55,9 @@ describe Travis::Addons::GithubStatus::Task do
   describe 'logging' do
     it 'warns about a failed request' do
       GH.stubs(:post).raises(GH::Error.new(nil))
-      run
+      expect {
+        run
+      }.to raise_error
       io.string.should include('[task]')
       io.string.should include('Could not update')
     end


### PR DESCRIPTION
If there's a temporary problem with the GitHub API, we should retry.

This currently has the downside that updates may be retried when we don't have a valid token.

Should we maybe look at the error in some more detail and only retry specific cases? If so, which ones?
