### PR TITLE
Grab all the known email addresses for the repo members

### DIFF
--- a/lib/travis/addons/email/event_handler.rb
+++ b/lib/travis/addons/email/event_handler.rb
@@ -38,7 +38,7 @@ module Travis
           end
 
           def default_recipients
-            recipients = object.repository.users.map(&:email)
+            recipients = object.repository.users.map {|u| u.emails.map(&:email)}.flatten
             recipients.keep_if do |r|
               r == object.commit.author_email or
               r == object.commit.committer_email

--- a/lib/travis/testing/stubs.rb
+++ b/lib/travis/testing/stubs.rb
@@ -275,6 +275,12 @@ module Travis
           last_modified: Time.at(0).utc
         )
       end
+
+      def stub_email(attributes = {})
+        Stubs.stub 'email', attributes.reverse_merge(
+          email: 'email'
+        )
+      end
     end
   end
 end

--- a/spec/travis/addons/email/event_handler_spec.rb
+++ b/spec/travis/addons/email/event_handler_spec.rb
@@ -7,7 +7,10 @@ describe Travis::Addons::Email::EventHandler do
   let(:subject) { Travis::Addons::Email::EventHandler }
   let(:payload) { Travis::Api.data(build, for: 'event', version: 'v0') }
   let(:repository) {
-    stub_repo(users: [stub_user(email: 'author-1@email.com'), stub_user(email: 'committer-1@email.com')])
+    stub_repo(users: [
+      stub_user(emails: [stub_email(email: 'author-1@email.com'   )]),
+      stub_user(emails: [stub_email(email: 'committer-1@email.com')])
+    ])
   }
 
   describe 'subscription' do

--- a/spec/travis/addons/email/instruments/event_handler_spec.rb
+++ b/spec/travis/addons/email/instruments/event_handler_spec.rb
@@ -8,7 +8,9 @@ describe Travis::Addons::Email::Instruments::EventHandler do
   let(:publisher) { Travis::Notification::Publisher::Memory.new }
   let(:event)     { publisher.events[1] }
   let(:repository) {
-    stub_repo(users: [stub_user(email: 'svenfuchs@artweb-design.de')])
+    stub_repo(users: [
+      stub_user(emails: [stub_email(email: 'svenfuchs@artweb-design.de')])
+    ])
   }
 
   before :each do


### PR DESCRIPTION
Reach into Users' emails models for email addresses, so that we can
filter from all the known email addresses.
