### PR TITLE
Correctly mark allowed failures for non-Ruby projects

### DIFF
--- a/lib/travis/model/build/matrix.rb
+++ b/lib/travis/model/build/matrix.rb
@@ -50,8 +50,8 @@ class Build
 
       def matrix_lang_keys(config)
         env_keys = ENV_KEYS
-        lang = config.symbolize_keys.fetch(:language, Build::Matrix::Config::DEFAULT_LANG)
-        env_keys &= EXPANSION_KEYS_LANGUAGE[lang]
+        lang = config.symbolize_keys[:language]
+        env_keys &= EXPANSION_KEYS_LANGUAGE[lang] if lang
         env_keys | EXPANSION_KEYS_UNIVERSAL
       end
     end

--- a/spec/travis/model/build/matrix_spec.rb
+++ b/spec/travis/model/build/matrix_spec.rb
@@ -285,17 +285,17 @@ describe Build, 'matrix' do
 
     let(:multiple_tests_config_with_allow_failures) {
       YAML.load <<-yml
+      language: objective-c
       rvm:
         - 1.8.7
         - 1.9.2
-      gemfile:
-        - gemfiles/rails-2.3.x
-        - gemfiles/rails-3.0.x
-        - gemfiles/rails-3.1.x
+      xcode_sdk:
+        - iphonesimulator6.1
+        - iphonesimulator7.0
       matrix:
         allow_failures:
-          - rvm: 1.9.2
-            gemfile: gemfiles/rails-2.3.x
+          - rvm: 1.8.7
+            xcode_sdk: iphonesimulator7.0
     yml
     }
 
@@ -398,7 +398,7 @@ describe Build, 'matrix' do
 
       it 'sets the config to the jobs (allow failures config)' do
         build = Factory(:build, config: multiple_tests_config_with_allow_failures)
-        build.matrix.map(&:allow_failure).should == [false, false, false, true, false, false]
+        build.matrix.map(&:allow_failure).should == [false, true, false, false]
       end
 
       it 'ignores global env config when setting allow failures' do


### PR DESCRIPTION
We use `Job#matrix_config?` to test if an `allow_failures` entry matches a job, which gets the keys to compare from `Build.matrix_keys_for`. Since the `allow_failures` entry doesn't include a `language` key, `Build.matrix_lang_keys` only returns the keys included that are "Ruby" keys, since Ruby is the default language. This in turn makes the config that `matrix_config?` tests against empty, causing no jobs to be marked as allowed failures.
