### PR TITLE
Deal with the case where `language` is an array

### DIFF
--- a/lib/travis/model/build/matrix.rb
+++ b/lib/travis/model/build/matrix.rb
@@ -50,7 +50,7 @@ class Build
 
       def matrix_lang_keys(config)
         env_keys = ENV_KEYS
-        lang = config.symbolize_keys[:language]
+        lang = Array(config.symbolize_keys[:language]).first
         env_keys &= EXPANSION_KEYS_LANGUAGE[lang] if lang
         env_keys | EXPANSION_KEYS_UNIVERSAL
       end

--- a/spec/travis/model/build/matrix_spec.rb
+++ b/spec/travis/model/build/matrix_spec.rb
@@ -603,10 +603,12 @@ describe Build, 'matrix' do
   describe 'matrix_keys_for' do
     let(:config_default_lang) { { 'rvm' => ['1.8.7', '1.9.2'], 'env' => ['DB=sqlite3', 'DB=postgresql'] } }
     let(:config_non_def_lang) { { 'language' => 'scala', 'rvm' => ['1.8.7', '1.9.2'], 'env' => ['DB=sqlite3', 'DB=postgresql'] } }
+    let(:config_lang_array)   { { 'language' => ['scala'], 'rvm' => ['1.8.7', '1.9.2'], 'env' => ['DB=sqlite3', 'DB=postgresql'] } }
 
     it 'only selects appropriate keys' do
       Build.matrix_keys_for(config_default_lang).should == [:rvm, :env]
       Build.matrix_keys_for(config_non_def_lang).should == [:env]
+      Build.matrix_keys_for(config_lang_array).should == [:env]
     end
   end
 end


### PR DESCRIPTION
Users shouldn't do this, since we only use one language in a build,
but some users have it, and it was a regression to not deal with this.
