### PR TITLE
Don't take pull requests into account for branches list

### DIFF
--- a/lib/travis/model/repository.rb
+++ b/lib/travis/model/repository.rb
@@ -144,7 +144,7 @@ class Repository < Travis::Model
     self.class.connection.select_values %(
       SELECT DISTINCT ON (branch) builds.id
       FROM   builds
-      WHERE  builds.repository_id = #{id}
+      WHERE  builds.repository_id = #{id} AND builds.event_type = 'push'
       ORDER  BY branch, finished_at DESC
       LIMIT  25
     )

--- a/spec/travis/model/repository_spec.rb
+++ b/spec/travis/model/repository_spec.rb
@@ -260,6 +260,8 @@ describe Repository do
       old = Factory(:build, repository: repo, finished_at: 1.hour.ago,      state: 'finished', commit: Factory(:commit, branch: 'one'))
       one = Factory(:build, repository: repo, finished_at: 1.hour.from_now, state: 'finished', commit: Factory(:commit, branch: 'one'))
       two = Factory(:build, repository: repo, finished_at: 1.hour.from_now, state: 'finished', commit: Factory(:commit, branch: 'two'))
+      three = Factory(:build, repository: repo, finished_at: 1.hour.from_now, state: 'finished', commit: Factory(:commit, branch: 'three'))
+      three.update_attribute(:event_type, 'pull_request')
 
       builds = repo.last_finished_builds_by_branches
       builds.size.should == 2


### PR DESCRIPTION
When we build a branches list, we should not take pull requests into
account, because they're not really on a given branch - they're just
targetted at it.
