### PR TITLE
feat(user): don't print the GitHub OAuth token for a user in the console

### DIFF
--- a/lib/travis/model/user.rb
+++ b/lib/travis/model/user.rb
@@ -122,6 +122,10 @@ class User < Travis::Model
     "https://0.gravatar.com/avatar/#{profile_image_hash}"
   end
 
+  def inspect
+    super.gsub(github_oauth_token, '[REDACTED]')
+  end
+
   protected
 
     def track_github_scopes

--- a/spec/travis/model/user_spec.rb
+++ b/spec/travis/model/user_spec.rb
@@ -211,4 +211,11 @@ describe User do
       user.should be_correct_scopes
     end
   end
+
+  describe 'inspect' do
+    it 'does not include the user\'s GitHub OAuth token' do
+      user.github_oauth_token = 'foobarbaz'
+      user.inspect.should_not include('foobarbaz')
+    end
+  end
 end


### PR DESCRIPTION
This removes the GitHub OAuth token from the 'inspect' output for a User instance.
