### PR TITLE
Use serializable transaction when adding new builds

### DIFF
--- a/lib/travis/retry_on.rb
+++ b/lib/travis/retry_on.rb
@@ -1,0 +1,18 @@
+module Travis
+  module RetryOn
+    def retry_on(*errors)
+      options = errors.last.is_a?(Hash) ? errors.pop : {}
+      tries = 0
+      max_tries = options[:max_tries] || 3
+      begin
+        yield
+      rescue *errors
+        tries += 1
+        if options[:sleep]
+          sleep options[:sleep]
+        end
+        tries < max_tries ? retry : raise
+      end
+    end
+  end
+end


### PR DESCRIPTION
From commit message:

```
Serializable transaction isolation level simulates serial transaction
execution, which will ensure that build numbers are unique. One of the
drawbacks of using serializable isolation level is that it can fail with
increased concurrency - that's why it's good to try retrying adding a
new build.
```

I'm not sure if there is any good way to test it. I've created a small script which tries to simulate concurrency in similar setting: https://gist.github.com/drogus/e445560ab26cb4fc59b3, it handles concurrency of 30 without failing to create a build, so we should be fine.

A better thing to do would be to create unique index, but that would mean renumbering existing builds. We may do this in the future, but meanwhile we can use this fix.
