### PR TITLE
chore(.travis.yml): don't test against MRI 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,10 @@ addons:
 rvm:
   - jruby-19mode
   - jruby-head
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - rbx-2.1.1
-jdk:
-  - oraclejdk7
+jdk: oraclejdk7
 matrix:
   fast_finish: true
   allow_failures:


### PR DESCRIPTION
We're not using this version of Ruby in any of our applications anymore, so testing against it is no longer necessary.

MRI 1.9.3 is also failing right now, so this should fix CI.
