### PR TITLE
fix(user): if a user is deleted, remove the associated records

### DIFF
--- a/lib/travis/model/user.rb
+++ b/lib/travis/model/user.rb
@@ -5,12 +5,12 @@ require 'travis/model/encrypted_column'
 class User < Travis::Model
   require 'travis/model/user/oauth'
 
-  has_many :tokens
-  has_many :memberships
-  has_many :organizations, :through => :memberships
-  has_many :permissions
-  has_many :repositories, :through => :permissions
-  has_many :emails
+  has_many :tokens, dependent: :destroy
+  has_many :memberships, dependent: :destroy
+  has_many :organizations, through: :memberships
+  has_many :permissions, dependent: :destroy
+  has_many :repositories, through: :permissions
+  has_many :emails, dependent: :destroy
 
   attr_accessible :name, :login, :email, :github_id, :github_oauth_token, :gravatar_id, :locale
 


### PR DESCRIPTION
This fixes the bug where a user was deleted, but the associated token wasn't, causing an exception in API when a request was made with that user's token.

So, while adding this to `token` was the only thing needed to fix that bug, I decided to go ahead and add it to the other records as well.
