### PR TITLE
Use user's permissions for RemoveLog service

### DIFF
--- a/lib/travis/services/remove_log.rb
+++ b/lib/travis/services/remove_log.rb
@@ -6,7 +6,7 @@ module Travis
       FORMAT = "Log removed by %s at %s"
 
       def run(params)
-        return nil unless job && authorized?
+        return nil unless job && can_remove?
 
         message = FORMAT % [current_user.name, DateTime.now.iso8601]
         if params[:reason]

--- a/spec/travis/services/remove_log_spec.rb
+++ b/spec/travis/services/remove_log_spec.rb
@@ -13,12 +13,13 @@ describe Travis::Services::RemoveLog do
   context 'when job is not finished' do
     before :each do
       job.stubs(:finished?).returns false
+      user.stubs(:permission?).with(:push, anything).returns true
     end
 
     it 'does not change log' do
       expect {
         service.run(params)
-      }.to_not change { service.log }
+      }.to_not change { service.log.reload.content }
     end
   end
 
@@ -30,7 +31,7 @@ describe Travis::Services::RemoveLog do
     it 'does not change log' do
       expect {
         service.run(params)
-      }.to_not change { service.log }
+      }.to_not change { service.log.reload.content }
     end
   end
 
@@ -38,6 +39,7 @@ describe Travis::Services::RemoveLog do
     before :all do
       find_by_id = stub
       find_by_id.stubs(:find_by_id).returns job
+      job.stubs(:finished?).returns true
       service.stubs(:scope).returns find_by_id
       user.stubs(:permission?).with(:push, anything).returns true
     end


### PR DESCRIPTION
Previous PR, #343, did not correctly test the user's permission to remove the log.
