### PR TITLE
fix(github-services): handle RecordNotUnique errors in find-or-create

### DIFF
--- a/lib/travis/github/services/find_or_create_org.rb
+++ b/lib/travis/github/services/find_or_create_org.rb
@@ -58,6 +58,8 @@ module Travis
             nullify_logins(organization.github_id, organization.login)
 
             organization
+          rescue ActiveRecord::RecordNotUnique
+            find
           end
 
           def avatar_url(github_data)

--- a/lib/travis/github/services/find_or_create_repo.rb
+++ b/lib/travis/github/services/find_or_create_repo.rb
@@ -35,6 +35,8 @@ module Travis
               Travis.logger.info(message)
             end
             Repository.create!(:owner_name => params[:owner_name], :name => params[:name], github_id: params[:github_id])
+          rescue ActiveRecord::RecordNotUnique
+            find
           end
       end
     end

--- a/lib/travis/github/services/find_or_create_user.rb
+++ b/lib/travis/github/services/find_or_create_user.rb
@@ -44,6 +44,8 @@ module Travis
             nullify_logins(user.github_id, user.login)
 
             user
+          rescue ActiveRecord::RecordNotUnique
+            find
           end
 
           def data


### PR DESCRIPTION
These can show up if the find_or_create service is called for the same object at the same time in different threads.
