### PR TITLE
Prevent exception when GitHub OAuth token is nil

### DIFF
--- a/lib/travis/model/user.rb
+++ b/lib/travis/model/user.rb
@@ -124,7 +124,11 @@ class User < Travis::Model
   end
 
   def inspect
-    super.gsub(github_oauth_token, '[REDACTED]')
+    if github_oauth_token
+      super.gsub(github_oauth_token, '[REDACTED]')
+    else
+      super
+    end
   end
 
   protected

--- a/spec/travis/model/user_spec.rb
+++ b/spec/travis/model/user_spec.rb
@@ -213,9 +213,24 @@ describe User do
   end
 
   describe 'inspect' do
-    it 'does not include the user\'s GitHub OAuth token' do
-      user.github_oauth_token = 'foobarbaz'
-      user.inspect.should_not include('foobarbaz')
+    context 'when user has GitHub OAuth token' do
+      before :each do
+        user.github_oauth_token = 'foobarbaz'
+      end
+
+      it 'does not include the user\'s GitHub OAuth token' do
+        user.inspect.should_not include('foobarbaz')
+      end
+    end
+
+    context 'when user has no GitHub OAuth token' do
+      before :each do
+        user.github_oauth_token = nil
+      end
+
+      it 'indicates nil GitHub OAuth token' do
+        user.inspect.should include('github_oauth_token: nil')
+      end
     end
   end
 end


### PR DESCRIPTION
User#inspect should not throw exception when the token is nil
