### PR TITLE
Add a repository_name and repository_slug to the template

### DIFF
--- a/lib/travis/addons/util/template.rb
+++ b/lib/travis/addons/util/template.rb
@@ -18,18 +18,20 @@ module Travis
 
         def args
           @args ||= {
-            repository:     data[:repository][:slug],
-            build_number:   data[:build][:number].to_s,
-            build_id:       data[:build][:id].to_s,
-            branch:         data[:commit][:branch],
-            commit:         data[:commit][:sha][0..6],
-            author:         data[:commit][:author_name],
-            commit_message: data[:commit][:message],
-            result:         data[:build][:state].to_s,
-            duration:       seconds_to_duration(data[:build][:duration]),
-            message:        message,
-            compare_url:    compare_url,
-            build_url:      build_url
+            repository:            data[:repository][:slug],
+            repository_slug:       data[:repository][:slug],
+            repository_name:       data[:repository][:name],
+            build_number:          data[:build][:number].to_s,
+            build_id:              data[:build][:id].to_s,
+            branch:                data[:commit][:branch],
+            commit:                data[:commit][:sha][0..6],
+            author:                data[:commit][:author_name],
+            commit_message:        data[:commit][:message],
+            result:                data[:build][:state].to_s,
+            duration:              seconds_to_duration(data[:build][:duration]),
+            message:               message,
+            compare_url:           compare_url,
+            build_url:             build_url
           }
         end
 

--- a/lib/travis/api/v0/event/build.rb
+++ b/lib/travis/api/v0/event/build.rb
@@ -49,6 +49,7 @@ module Travis
                 'id' => repository.id,
                 'key' => repository.key.try(:public_key),
                 'slug' => repository.slug,
+                'name' => repository.name,
                 'owner_email' => repository.owner_email,
                 'owner_avatar_url' => repository.owner.try(:avatar_url)
               }

--- a/spec/travis/addons/util/template_spec.rb
+++ b/spec/travis/addons/util/template_spec.rb
@@ -5,6 +5,8 @@ describe Travis::Addons::Util::Template do
 
   VAR_NAMES = %w(
     repository
+    repository_slug
+    repository_name
     build_number
     build_id
     branch
@@ -28,6 +30,14 @@ describe Travis::Addons::Util::Template do
       result.should =~ %r(repository=svenfuchs/minimal)
     end
 
+    it 'replaces the repository slug' do
+      result.should =~ %r(repository_slug=svenfuchs/minimal)
+    end
+
+    it 'replaces the repository name' do
+      result.should =~ %r(repository_name=minimal)
+    end
+
     it 'replaces the build_number' do
       result.should =~ /build_number=#{build.number}/
     end
@@ -43,7 +53,7 @@ describe Travis::Addons::Util::Template do
     it 'replaces the author' do
       result.should =~ /author=Sven Fuchs/
     end
-    
+
     it 'replaces the duration' do
       result.should =~ /duration=1 min 0 sec/
     end


### PR DESCRIPTION
Hi, 

First PR, starting with an easy one referring to travis-ci/travis-ci#1426 . I don't know if **repository_short_name** sounds good to you. If it doesn't I will change with pleasure.

The best option would be to rename **repository** in **repository_slug** and add a **repository_name** field but it will break the current API.

I will change the doc right after the merge. It's [here](https://github.com/travis-ci/docs-travis-ci-com/blob/gh-pages/user/notifications.md#irc-notification) right ?
