### PR TITLE
allow per-channel key to be specified for IRC notifications

### DIFF
--- a/lib/travis/addons/irc/task.rb
+++ b/lib/travis/addons/irc/task.rb
@@ -52,7 +52,7 @@ module Travis
 
           def send_message(client, channel)
             channel, key = channel.split ',', 2
-            client.join(channel, key) if join?
+            client.join(channel, key || try_config(:channel_key) || nil) if join?
             messages.each { |message| client.say("[travis-ci] #{message}", channel, notice?) }
             client.leave(channel) if join?
           end

--- a/spec/travis/addons/irc/task_spec.rb
+++ b/spec/travis/addons/irc/task_spec.rb
@@ -210,7 +210,7 @@ describe Travis::Addons::Irc::Task do
     run
   end
 
-  it 'allows setting a channel key' do
+  it 'allows setting a channel key in the channel declaration' do
     payload['build']['config']['notifications'] = { irc: { use_notice: true } }
 
     expect_irc 'irc.freenode.net', 1234, 'travis', [
@@ -226,6 +226,21 @@ describe Travis::Addons::Irc::Task do
     run(['irc.freenode.net:1234#travis,pass'])
   end
 
+  it 'allows setting a global channel key' do
+    payload['build']['config']['notifications'] = { irc: { use_notice: true, channel_key: 'pass' } }
+
+    expect_irc 'irc.freenode.net', 1234, 'travis', [
+      'NICK travis-ci',
+      'USER travis-ci travis-ci travis-ci :travis-ci',
+      'JOIN #travis pass',
+      'NOTICE #travis :[travis-ci] svenfuchs/minimal#2 (master - 62aae5f : Sven Fuchs): The build passed.',
+      'NOTICE #travis :[travis-ci] Change view : https://github.com/svenfuchs/minimal/compare/master...develop',
+      'NOTICE #travis :[travis-ci] Build details : http://travis-ci.org/svenfuchs/minimal/builds/1',
+      'PART #travis',
+      'QUIT'
+    ]
+    run
+  end
 
   it 'wrap socket with ssl (in client private) when configured to IRC+SSL server' do
     Travis::Addons::Irc::Client.expects(:wrap_ssl).with(tcp).returns(tcp)


### PR DESCRIPTION
This should fix https://github.com/travis-ci/travis-ci/issues/1628 by allowing the specification of an IRC key on a per-channel basis, by appending ",$key" to the channel definition:

```
 irc:
    channels:
      - irc.oftc.net#akerl,sekrit
      - irc.freenode.net#coolkids,password
```

I chose "," as the delimiter because, as per my understanding, it will not occur in an IRC channel name.
