### PR TITLE
[WIP] Add XMPP notifications travis-ci/travis-ci#958

### DIFF
--- a/lib/travis/addons.rb
+++ b/lib/travis/addons.rb
@@ -13,6 +13,7 @@ module Travis
     require 'travis/addons/sqwiggle'
     require 'travis/addons/webhook'
     require 'travis/addons/slack'
+    require 'travis/addons/xmpp'
 
     class << self
       def register

--- a/lib/travis/addons/xmpp.rb
+++ b/lib/travis/addons/xmpp.rb
@@ -1,0 +1,10 @@
+module Travis
+  module Addons
+    module Xmpp
+      require 'travis/addons/xmpp/instruments'
+      require 'travis/addons/xmpp/event_handler'
+
+      class Task < ::Travis::Task; end
+    end
+  end
+end

--- a/lib/travis/addons/xmpp/event_handler.rb
+++ b/lib/travis/addons/xmpp/event_handler.rb
@@ -1,0 +1,32 @@
+module Travis
+  module Addons
+    module Xmpp
+      # Publishes a build notification to XMPP rooms or users as defined in the
+      # configuration (`.travis.yml`).
+      #
+      # XMPP credentials are encrypted using the repository's ssl key.
+      class EventHandler < Event::Handler
+        API_VERSION = 'v2'
+
+        EVENTS = /build:finished/
+
+        def handle?
+          !pull_request? && targets.present? && config.send_on_finished_for?(:xmpp)
+        end
+
+        def handle
+          Travis::Addons::XMPP::Task.run(:xmpp, payload, targets: targets)
+        end
+
+        def targets
+          @targets ||= {
+            rooms: config.notification_values(:xmpp, :rooms),
+            users: config.notification_values(:xmpp, :users)
+          }
+        end
+
+        Instruments::EventHandler.attach_to(self)
+      end
+    end
+  end
+end

--- a/lib/travis/addons/xmpp/instruments.rb
+++ b/lib/travis/addons/xmpp/instruments.rb
@@ -1,0 +1,26 @@
+module Travis
+  module Addons
+    module Xmpp
+      module Instruments
+        class EventHandler < Notification::Instrument::EventHandler
+          def notify_completed
+            publish(:targets => handler.targets)
+          end
+        end
+
+        class Task < Notification::Instrument::Task
+          def run_completed
+            publish(
+              :msg => "for #<Build id=#{payload[:build][:id]}>",
+              :repository => payload[:repository][:slug],
+              :object_type => 'Build',
+              :object_id => payload[:build][:id],
+              :targets => task.targets,
+              :message => task.message
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/event/config.rb
+++ b/lib/travis/event/config.rb
@@ -4,9 +4,10 @@ module Travis
   module Event
     class Config
       DEFAULTS = {
-        start:   { email: false,   webhooks: false,   campfire: false,   hipchat: false,   irc: false,   flowdock: false, sqwiggle: false, slack: false },
-        success: { email: :change, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always },
-        failure: { email: :always, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always }
+        start:   { email: false,   webhooks: false,   campfire: false,   hipchat: false,   irc: false,   flowdock: false, sqwiggle: false, slack: false, xmpp: false },
+        success: { email: :change, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, xmpp: :always},
+        failure: { email: :always, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, xmpp: :always}
+
       }
 
       attr_reader :payload, :build, :secure_key, :config

--- a/spec/travis/addons/xmpp/instruments/event_handler_spec.rb
+++ b/spec/travis/addons/xmpp/instruments/event_handler_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Travis::Addons::Xmpp::Instruments::EventHandler do
+  include Travis::Testing::Stubs
+
+  let(:subject)   { Travis::Addons::Xmpp::EventHandler }
+  let(:publisher) { Travis::Notification::Publisher::Memory.new }
+  let(:build)     { stub_build(config: { notifications: { xmpp: { users: ["one@example.com"] } } } ) }
+  let(:event)     { publisher.events[1] }
+
+  before :each do
+    Travis::Notification.publishers.replace([publisher])
+    subject.any_instance.stubs(:handle)
+    subject.notify('build:finished', build)
+  end
+
+  it 'publishes a event' do
+    event.should publish_instrumentation_event(
+      event: 'travis.addons.xmpp.event_handler.notify:completed',
+      message: 'Travis::Addons::Xmpp::EventHandler#notify:completed (build:finished) for #<Build id=1>',
+    )
+    event[:data].except(:payload).should == {
+      repository: 'svenfuchs/minimal',
+      request_id: 1,
+      object_id: 1,
+      object_type: 'Build',
+      event: 'build:finished',
+      targets: { rooms: nil, users: ["one@example.com"] }
+    }
+    event[:data][:payload].should_not be_nil
+  end
+end
+


### PR DESCRIPTION
Hi Everybody !

This is my first try at implementing XMPP notifications. Some information about this implementation : 

- I've tested the whole Client/Task duo and it works for both Room and User notification :v: 
- It uses the gem [XMPP4R](https://github.com/xmpp4r/xmpp4r), this is criticizable, so let me know if you need an implementation from scratch (which not easy).
- I didn't test the "whole process", from a successful build to a XMPP notification. I will need some help here.
- ~~I didn't handle the exceptions, I looked at the other Services (like Flowdock) and it doesn't seem to do it too, is it a design choice ? I could be plain wrong, and I will be glad to implement the needed rescues.~~ I added some rescues in message sending method.
- I don't find my specs to be particularly insightful. I will try to add more useful ones.
- The user need to have a XMPP account. If Travis chooses to provide its owns it could be optional.

The configuration format support two kind of notifications : rooms (with or without passwords) and users.

It looks like this : 
```yaml
notifications:
  xmpp:
    jid: 'awesome_travis_user@example.com'
    password: 'password'
    rooms:
      - jid: mainhall@example.com/anAwesomePseudo
      - jid: secretroom@example.com/TravisBot
        password: 'password'
    users:
      - one@example.com
      - two@example.com
    template:
      - "%{repository} (%{commit}) : %{message} %{foo} "
      - "Build details: %{build_url}"
```

Comments and Reviews really welcome.

Enjoy.

Ref : travis-ci/travis-ci#958