### PR TITLE
Handle matrix definitions with lists in them.

### DIFF
--- a/lib/travis/model/build/config/matrix.rb
+++ b/lib/travis/model/build/config/matrix.rb
@@ -31,7 +31,9 @@ class Build
       private
 
         def settings
-          config[:matrix] || {}
+          @_settings ||= config[:matrix] || {}
+          @_settings = {} if @_settings.is_a?(Array)
+          @_settings
         end
 
         def expand_matrix

--- a/spec/travis/model/build/config/matrix_spec.rb
+++ b/spec/travis/model/build/config/matrix_spec.rb
@@ -7,4 +7,8 @@ describe Build::Config::Matrix do
   it 'can handle nil values in exclude matrix' do
     -> { Build::Config::Matrix.new(matrix: { exclude: [nil] }).expand }.should_not raise_error
   end
+
+  it 'can handle list values in exclude matrix' do
+    -> { Build::Config::Matrix.new(matrix: []).expand }.should_not raise_error
+  end
 end


### PR DESCRIPTION
This currently ignores the list. This occasionally happens when a user has a list of environment variables in the `matrix` section rather than in an `env` section.

An alternative would be to hoist any list definition to the `env` section.

What do you think?
