### PR TITLE
[WIP][sanity check needed] Config validator

### DIFF
--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -2,6 +2,7 @@ require 'active_record'
 require 'core_ext/active_record/base'
 require 'core_ext/hash/deep_symbolize_keys'
 require 'simple_states'
+require 'travis/model/build/config_validator'
 
 # Build currently models a central but rather abstract domain entity: the thing
 # that is triggered by a Github request (service hook ping).

--- a/lib/travis/model/build/config_validator.rb
+++ b/lib/travis/model/build/config_validator.rb
@@ -1,0 +1,55 @@
+class Build < Travis::Model
+  class GenericValidator
+    class Entry < Struct.new(:name, :options)
+
+      def self.entries
+        @entries ||= {}
+      end
+    end
+
+    def self.entry(name, options, &block)
+      p [:entry, name, options]
+      entry = Entry.new(name, options)
+      _entries = @current_entry ? @current_entry.entries : entries
+      entries[name] = entry
+
+      if block
+        @current_entry = entry.entries
+        instance_eval(&block)
+        @current_entry = nil
+      end
+    end
+
+    def self.values(type, options)
+      p [:values, type, options]
+    end
+
+    def self.entries
+      @entries ||= {}
+    end
+
+    delegate :entries, to: 'self.class.entries'
+    attr_reader :payload
+
+    def initialize(payload)
+      @payload = payload
+    end
+
+    def valid?
+      entries.all? do |entry|
+        true
+      end
+    end
+  end
+
+  class ConfigValidator < GenericValidator
+    entry :language, type: :string
+
+    entry :env, type: [:string, :array, :hash] do
+      entry :global, type: [:string, :array]
+      entry :matrix, type: [:string, :array]
+
+      values :string, for: :array
+    end
+  end
+end

--- a/spec/travis/model/build/config_validator_spec.rb
+++ b/spec/travis/model/build/config_validator_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Build::GenericValidator do
+  attr_reader :validator_class
+
+  context 'with a nested hash, string or array' do
+    before do
+      @validator_class = Class.new(Build::GenericValidator) do
+        entry :env, type: [:string, :array, :hash] do
+          entry :global, type: [:string, :array] do
+            values for: :array, only: [:string, :hash]
+          end
+          entry :matrix, type: [:string, :array] do
+            values for: :array, only: [:string, :hash]
+          end
+
+          values for: :array, only: [:string]
+        end
+      end
+
+    end
+
+    it 'allows env to be a string' do
+      validator_class.new('env' => 'FOO=bar').should be_valid
+    end
+
+    it 'allows env to be a hash' do
+      validator_class.new('env' => {}).should be_valid
+    end
+
+    it 'allows env to be an array of strings' do
+      validator_class.new('env' => ['FOO=bar']).should be_valid
+    end
+  end
+end


### PR DESCRIPTION
A while ago I started preparing a simple config validator which would allow us to reject requests if the config is malformed (like: a user puts an array instead of hash or something like that).

The idea is to have a simple DSL which would allow us to specify what's allowed and what's not, like:

``` ruby
entry :env, type: [:string, :array, :hash] do
  entry :global, type: [:string, :array] do
    values for: :array, only: [:string, :hash]
  end
  entry :matrix, type: [:string, :array] do
    values for: :array, only: [:string, :hash]
  end

  values for: :array, only: [:string]
end
```

As @roidrage is trying to get rid of various small errors, I think this would greatly simplify things, because we would not have to worry about malformed values in config. With requests API in place it will be also easier to communicate a problem to the user. I was reluctant to work more on config validator in the past, because without a way to see why builds are not showing up it would create a really poor experience.

Another possible way to handle that is to "objectify" the config, so instead of handling everything as yml/json:

``` ruby
if config[:env] && config[:env][:something] && config[:env][:something][:something_else]
```

we could do something like:

``` ruby
config.env #=> Build::Config::Env instance
config.env.global #=> ["FOO=bar"]
config.env.matrix  #=> ["BAR=baz"]
```

What do you think about that? Should I continue with config validator as a DSL, or do you think that creating a definitions for parts of config would be a better approach?
