### PR TITLE
Enabling notifications to be sent from PRs

### DIFF
--- a/lib/travis/addons/campfire/event_handler.rb
+++ b/lib/travis/addons/campfire/event_handler.rb
@@ -12,7 +12,7 @@ module Travis
         EVENTS = /build:finished/
 
         def handle?
-          !pull_request? && targets.present? && config.send_on_finished_for?(:campfire)
+          enabled? && targets.present? && config.send_on_finished_for?(:campfire)
         end
 
         def handle
@@ -23,7 +23,15 @@ module Travis
           @targets ||= config.notification_values(:campfire, :rooms)
         end
 
-        Instruments::EventHandler.attach_to(self)
+        private
+
+          def enabled?
+            enabled = config.notification_values(:campfire, :on_pull_requests)
+            enabled = false if enabled.nil? or !(!!enabled == enabled) # configuration returns a non boolean if key is not found
+            pull_request? ? enabled : true
+          end
+
+          Instruments::EventHandler.attach_to(self)
       end
     end
   end

--- a/lib/travis/addons/email/event_handler.rb
+++ b/lib/travis/addons/email/event_handler.rb
@@ -9,7 +9,7 @@ module Travis
         EVENTS = 'build:finished'
 
         def handle?
-          !pull_request? && config.enabled?(:email) && config.send_on_finished_for?(:email) && recipients.present?
+          enabled? && config.enabled?(:email) && config.send_on_finished_for?(:email) && recipients.present?
         end
 
         def handle
@@ -43,6 +43,12 @@ module Travis
               r == object.commit.author_email or
               r == object.commit.committer_email
             end
+          end
+
+          def enabled?
+            enabled = config.notification_values(:email, :on_pull_requests)
+            enabled = false if enabled.nil? or !(!!enabled == enabled) # configuration returns a non boolean if key is not found
+            pull_request? ? enabled : true
           end
 
           Instruments::EventHandler.attach_to(self)

--- a/lib/travis/addons/flowdock/event_handler.rb
+++ b/lib/travis/addons/flowdock/event_handler.rb
@@ -17,7 +17,7 @@ module Travis
         end
 
         def handle?
-          !pull_request? && targets.present? && config.send_on_finished_for?(:flowdock)
+          enabled? && targets.present? && config.send_on_finished_for?(:flowdock)
         end
 
         def handle
@@ -28,7 +28,15 @@ module Travis
           @targets ||= config.notification_values(:flowdock, :rooms)
         end
 
-        Instruments::EventHandler.attach_to(self)
+        private
+
+          def enabled?
+            enabled = config.notification_values(:flowdock, :on_pull_requests)
+            enabled = false if enabled.nil? or !(!!enabled == enabled) # configuration returns a non boolean if key is not found
+            pull_request? ? enabled : true
+          end
+
+          Instruments::EventHandler.attach_to(self)
       end
     end
   end

--- a/lib/travis/addons/hipchat/event_handler.rb
+++ b/lib/travis/addons/hipchat/event_handler.rb
@@ -19,17 +19,19 @@ module Travis
           Travis::Addons::Hipchat::Task.run(:hipchat, payload, targets: targets)
         end
 
-        def enabled?
-          enabled = config.notification_values(:hipchat, :on_pull_requests)
-          enabled = true if enabled.nil?
-          pull_request? ? enabled : true
-        end
-
         def targets
           @targets ||= config.notification_values(:hipchat, :rooms)
         end
 
-        Instruments::EventHandler.attach_to(self)
+        private
+
+          def enabled?
+            enabled = config.notification_values(:hipchat, :on_pull_requests)
+            enabled = false if enabled.nil? or !(!!enabled == enabled) # configuration returns a non boolean if key is not found
+            pull_request? ? enabled : true
+          end
+
+          Instruments::EventHandler.attach_to(self)
       end
     end
   end

--- a/lib/travis/addons/irc/event_handler.rb
+++ b/lib/travis/addons/irc/event_handler.rb
@@ -10,7 +10,7 @@ module Travis
         EVENTS = 'build:finished'
 
         def handle?
-          !pull_request? && channels.present? && config.send_on_finished_for?(:irc)
+          enabled? && channels.present? && config.send_on_finished_for?(:irc)
         end
 
         def handle
@@ -21,7 +21,15 @@ module Travis
           @channels ||= config.notification_values(:irc, :channels)
         end
 
-        Instruments::EventHandler.attach_to(self)
+        private
+
+          def enabled?
+            enabled = config.notification_values(:irc, :on_pull_requests)
+            enabled = false if enabled.nil? or !(!!enabled == enabled) # configuration returns a non boolean if key is not found
+            pull_request? ? enabled : true
+          end
+
+          Instruments::EventHandler.attach_to(self)
       end
     end
   end

--- a/spec/travis/addons/campfire/event_handler_spec.rb
+++ b/spec/travis/addons/campfire/event_handler_spec.rb
@@ -53,9 +53,23 @@ describe Travis::Addons::Campfire::EventHandler do
       notify
     end
 
-    it 'does not trigger a task if the build is a pull request' do
+    it 'does not trigger a task if the build is a pull request and notifications settings are preset' do
       build.stubs(:pull_request?).returns(true)
       task.expects(:run).never
+      notify
+    end
+
+    it "does not trigger when pull request notifications are disabled" do
+      build.stubs(:config => { :notifications => { :campfire => { on_pull_requests: false } } })
+      build.stubs(:pull_request?).returns(true)
+      task.expects(:run).never
+      notify
+    end
+
+    it "trigger when pull request notifications are enabled" do
+      build.stubs(:config => { :notifications => { :campfire => { on_pull_requests: true, rooms: ['room'] } } })
+      build.stubs(:pull_request?).returns(true)
+      task.expects(:run).with(:campfire, payload, targets: ['room'])
       notify
     end
 

--- a/spec/travis/addons/email/event_handler_spec.rb
+++ b/spec/travis/addons/email/event_handler_spec.rb
@@ -52,9 +52,23 @@ describe Travis::Addons::Email::EventHandler do
       notify
     end
 
-    it 'does not trigger a task if the build is a pull request' do
+    it 'does not trigger a task if the build is a pull request and notifications settings are preset' do
       build.stubs(:pull_request?).returns(true)
       task.expects(:run).never
+      notify
+    end
+
+    it "does not trigger when pull request notifications are disabled" do
+      build.stubs(:config => { :notifications => { :email => { on_pull_requests: false, recipients: 'svenfuchs@artweb-design.de' } } })
+      build.stubs(:pull_request?).returns(true)
+      task.expects(:run).never
+      notify
+    end
+
+    it "trigger when pull request notifications are enabled" do
+      build.stubs(:config => { :notifications => { :email => { on_pull_requests: true, recipients: 'svenfuchs@artweb-design.de' } } })
+      build.stubs(:pull_request?).returns(true)
+      task.expects(:run).with(:email, payload, params)
       notify
     end
 

--- a/spec/travis/addons/flowdock/event_handler_spec.rb
+++ b/spec/travis/addons/flowdock/event_handler_spec.rb
@@ -44,9 +44,23 @@ describe Travis::Addons::Flowdock::EventHandler do
       notify
     end
 
-    it 'does not trigger a task if the build is a pull request' do
+    it 'does not trigger a task if the build is a pull request and notifications settings are preset' do
       build.stubs(:pull_request?).returns(true)
       task.expects(:run).never
+      notify
+    end
+
+    it "does not trigger when pull request notifications are disabled" do
+      build.stubs(:config => { :notifications => { :flowdock => { on_pull_requests: false } } })
+      build.stubs(:pull_request?).returns(true)
+      task.expects(:run).never
+      notify
+    end
+
+    it "trigger when pull request notifications are enabled" do
+      build.stubs(:config => { :notifications => { :flowdock => { on_pull_requests: true, rooms: ['room'] } } })
+      build.stubs(:pull_request?).returns(true)
+      task.expects(:run).with(:flowdock, payload, targets: ['room'])
       notify
     end
 

--- a/spec/travis/addons/hipchat/event_handler_spec.rb
+++ b/spec/travis/addons/hipchat/event_handler_spec.rb
@@ -44,16 +44,23 @@ describe Travis::Addons::Hipchat::EventHandler do
       notify
     end
 
-    it 'triggers a task if the build is a pull request' do
+    it 'does not trigger a task if the build is a pull request and notifications settings are preset' do
       build.stubs(:pull_request?).returns(true)
-      task.expects(:run).with(:hipchat, payload, targets: ['room'])
+      task.expects(:run).never
       notify
     end
 
-    it "doesn't trigger when pull request notifications are disabled" do
+    it "does not trigger when pull request notifications are disabled" do
       build.stubs(:config => { :notifications => { :hipchat => { on_pull_requests: false } } })
       build.stubs(:pull_request?).returns(true)
       task.expects(:run).never
+      notify
+    end
+
+    it "trigger when pull request notifications are enabled" do
+      build.stubs(:config => { :notifications => { :hipchat => { on_pull_requests: true, rooms: ['room'] } } })
+      build.stubs(:pull_request?).returns(true)
+      task.expects(:run).with(:hipchat, payload, targets: ['room'])
       notify
     end
 

--- a/spec/travis/addons/irc/event_handler_spec.rb
+++ b/spec/travis/addons/irc/event_handler_spec.rb
@@ -44,9 +44,23 @@ describe Travis::Addons::Irc::EventHandler do
       notify
     end
 
-    it 'does not trigger a task if the build is a pull request' do
+    it 'does not trigger a task if the build is a pull request and notifications settings are preset' do
       build.stubs(:pull_request?).returns(true)
       task.expects(:run).never
+      notify
+    end
+
+    it "does not trigger when pull request notifications are disabled" do
+      build.stubs(:config => { :notifications => { :irc => { on_pull_requests: false} } })
+      build.stubs(:pull_request?).returns(true)
+      task.expects(:run).never
+      notify
+    end
+
+    it "trigger when pull request notifications are enabled" do
+      build.stubs(:config => { :notifications => { :irc => { on_pull_requests: true, channels: ['irc.freenode.net#travis'] } } })
+      build.stubs(:pull_request?).returns(true)
+      task.expects(:run).with(:irc, payload, channels: ['irc.freenode.net#travis'])
       notify
     end
 


### PR DESCRIPTION
Enabling notification to sent from PRs for _Campfire_, _Email_, _FlowDock_, _Hipchat_ and _IRC_ using `on_pull_requests` configuration setting making the notification rule consistent among these services.

Attempt to solve travis-ci/travis-ci#2128
Docs updated at travis-ci/docs-travis-ci-com#46
