### PR TITLE
Add a public field to env vars

### DIFF
--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -9,6 +9,7 @@ class Repository::Settings
 
   class SshKey < Model
     field :name
+    field :public, default: false
     field :content, encrypted: true
 
     validates :name, presence: true

--- a/lib/travis/model/repository/settings/field.rb
+++ b/lib/travis/model/repository/settings/field.rb
@@ -16,6 +16,10 @@ class Repository::Settings
     attr_reader :encrypted, :default
     alias encrypted? encrypted
 
+    def default?
+      !default.nil?
+    end
+
     def initialize(name, type, options)
       super
       @encrypted = true if options[:encrypted] || options['encrypted']
@@ -28,6 +32,9 @@ class Repository::Settings
     end
 
     def get(value, options = {})
+      if value.nil? && default?
+        value = default
+      end
       wrap_as_encrypted(coerce(value), options[:key])
     end
 

--- a/spec/travis/model/repository/settings/model_spec.rb
+++ b/spec/travis/model/repository/settings/model_spec.rb
@@ -8,9 +8,18 @@ describe Repository::Settings::Model do
       field :name
       field :loves_travis, :boolean
       field :height, :integer
+      field :awesome, :boolean, default: true
 
       field :secret, encrypted: true
     end
+  end
+
+  it 'returns a default if it is set' do
+    model_class.new.awesome.should be_true
+  end
+
+  it 'allows to override the default' do
+    model_class.new(awesome: false).awesome.should be_false
   end
 
   it 'validates encrypted fields properly' do


### PR DESCRIPTION
In the first version of environment variables which I already merged, I only added 2 fields to env var: name and value. The problem with this is that all of these variables would have to be shown in the build log as:

```
export FOO=[secret]
export BAR=[secret]
```

It's easy to imagine that you would like to add all of the variables needed for one thing in the UI, for example: S3_BUCKET, S3_KEY, S3_SECRET_KEY and for clarity, it would be nice if these could be displayed as:

```
export S3_BUCKET=a-bucket
export S3_key=[secret]
export S3_SECRET_KEY=[secret]
```

which is a bit more readable than showing everything as "secret"

This PR adds a public key to `EnvVar` model, which is false by default. It will be used to determine if a value of a variable can be shown in the UI and in logs. It will still be encrypted in the database, to keep implementation simpler.
