### PR TITLE
Return the right commit range for pull requests

### DIFF
--- a/lib/travis/model/commit.rb
+++ b/lib/travis/model/commit.rb
@@ -19,7 +19,9 @@ class Commit < Travis::Model
   end
 
   def range
-    if compare_url && compare_url =~ /\/([0-9a-f]+\^*\.\.\.[0-9a-f]+\^*$)/
+    if pull_request?
+      "#{request.base_commit}...#{request.head_commit}"
+    elsif compare_url && compare_url =~ /\/([0-9a-f]+\^*\.\.\.[0-9a-f]+\^*$)/
       $1
     end
   end

--- a/spec/travis/model/commit_spec.rb
+++ b/spec/travis/model/commit_spec.rb
@@ -77,5 +77,16 @@ describe Commit do
         commit.range.should be_nil
       end
     end
+
+    context 'for a pull request' do
+      before do
+        commit.ref = 'refs/pull/1/merge'
+        commit.request = Request.new(:base_commit => 'abcdef', :head_commit => '123456')
+      end
+
+      it 'returns range' do
+        commit.range.should == 'abcdef...123456'
+      end
+    end
   end
 end


### PR DESCRIPTION
The compare URL for pull requests is just the pull request URL, so we can't extract the commit range from it, but the commit range is stored in the request for pull requests, so we can get it from there.

Fixes travis-ci/travis-ci#1719.