### PR TITLE
Add feature flip for template selection

### DIFF
--- a/lib/travis/github/services/fetch_config.rb
+++ b/lib/travis/github/services/fetch_config.rb
@@ -58,6 +58,10 @@ module Travis
               config = config.except('osx_image')
             end
 
+            unless Travis::Features.active?(:template_selection, request.repository)
+              config = config.except('dist').except('group')
+            end
+
             config
           end
 

--- a/spec/travis/github/services/fetch_config_spec.rb
+++ b/spec/travis/github/services/fetch_config_spec.rb
@@ -69,6 +69,34 @@ describe Travis::Github::Services::FetchConfig do
         result.has_key?("osx_image").should be false
       end
     end
+
+    context "when the repository has the template_selection feature enabled" do
+      before do
+        Travis::Features.activate_repository(:template_selection, request.repository)
+      end
+
+      it "passes the 'group' config key through" do
+        GH.stubs(:[]).returns({ "content" => ["group: latest"].pack("m") })
+        result["group"].should eql("latest")
+      end
+
+      it "passes the 'dist' config key through" do
+        GH.stubs(:[]).returns({ "content" => ["dist: latest"].pack("m") })
+        result["dist"].should eql("latest")
+      end
+    end
+
+    context "when the repository doesn't have the template_selection feature enabled" do
+      it "doesn't pass the 'group' config key through" do
+        GH.stubs(:[]).returns({ "content" => ["group: latest"].pack("m") })
+        result.has_key?("group").should be false
+      end
+
+      it "doesn't pass the 'dist' config key through" do
+        GH.stubs(:[]).returns({ "content" => ["dist: latest"].pack("m") })
+        result.has_key?("dist").should be false
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Drop 'dist' and 'group' keys from config if :template_selection
feature is not enabled.

This corresponds to worker PR
https://github.com/travis-ci/travis-worker/pull/97.
