### PR TITLE
Repo timeout settings: treat 0 as nil

### DIFF
--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -101,6 +101,16 @@ class Repository::Settings < Travis::Settings
     false
   end
 
+  def timeout_hard_limit
+    value = super
+    value == 0 ? nil : value
+  end
+
+  def timeout_log_silence
+    value = super
+    value == 0 ? nil : value
+  end
+
   def repository_id
     additional_attributes[:repository_id]
   end

--- a/spec/travis/model/repository/settings_spec.rb
+++ b/spec/travis/model/repository/settings_spec.rb
@@ -66,6 +66,14 @@ describe Repository::Settings do
           settings(type, nil).should be_valid
         end
 
+        it 'returns nil if set to 0' do
+          settings(type, 0).send(:"timeout_#{type}").should be_nil
+        end
+
+        it "is valid if #{type} is set to 0" do
+          settings(type, 0).should be_valid
+        end
+
         [:off, :on].each do |status|
           describe "with :custom_timeouts feature flag turned #{status}" do
             max = MAX[status][type]
@@ -95,10 +103,6 @@ describe Repository::Settings do
             describe 'is invalid' do
               it "if #{type} is < 0" do
                 settings(type, -1).should_not be_valid
-              end
-
-              it "if #{type} is == 0" do
-                settings(type, 0).should_not be_valid
               end
 
               it "if #{type} is > #{max}" do


### PR DESCRIPTION
Saving repo settings currently seems to always pass `0`. If a timeout is 0 then the worker will actually use it, and error immediately.

This change makes repo settings return `nil` if set to `0`, so the payload passed to the worker should contain `nil`.
