### PR TITLE
Fix user_sync/repositories to not explode on GH errors

### DIFF
--- a/lib/travis/github/services/sync_user/repositories.rb
+++ b/lib/travis/github/services/sync_user/repositories.rb
@@ -90,7 +90,7 @@ module Travis
             end
 
             def fetch
-              resources.map { |resource| fetch_resource(resource) }.map(&:to_a).flatten.compact
+              resources.flat_map { |resource| Array(fetch_resource(resource)) }
             end
             instrument :fetch, :level => :debug
 
@@ -98,6 +98,7 @@ module Travis
               GH[resource] # TODO should be: ?type=#{self.class.type} but GitHub doesn't work as documented
             rescue GH::Error => e
               log_exception(e)
+              nil
             end
 
             def with_github(&block)

--- a/spec/travis/github/services/sync_user/repositories_spec.rb
+++ b/spec/travis/github/services/sync_user/repositories_spec.rb
@@ -127,6 +127,11 @@ describe Travis::Github::Services::SyncUser::Repositories do
       sync.run
     end
   end
+
+  it 'does not explode on GH errors' do
+    GH.expects(:[]).with('user/repos').raises(GH::Error.new)
+    expect { sync.run }.to_not raise_error
+  end
 end
 
 describe Travis::Github::Services::SyncUser::Repositories::Instrument do


### PR DESCRIPTION
Fixes https://app.getsentry.com/travis-ci/travis-gatekeeper/group/34761999/
