### PR TITLE
Fix Build#config= to deep_symbolize_keys, and fix the respective spec to not use Build#config

### DIFF
--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -174,7 +174,7 @@ class Build < Travis::Model
   alias addons_enabled? secure_env_enabled?
 
   def config=(config)
-    super(config || {})
+    super((config || {}).deep_symbolize_keys)
   end
 
   def config

--- a/spec/travis/model/build_spec.rb
+++ b/spec/travis/model/build_spec.rb
@@ -229,7 +229,7 @@ describe Build do
 
       it 'deep_symbolizes keys on write' do
         build = Factory(:build, config: { 'foo' => { 'bar' => 'bar' } })
-        build.config[:foo][:bar].should == 'bar'
+        build.read_attribute(:config)[:foo].should == { bar: 'bar' }
       end
     end
 


### PR DESCRIPTION
This broke notifications on both org and com, because hub was not updated to the same travis-core version.
