### PR TITLE
request/receive api: allow passing a custom commit message

### DIFF
--- a/lib/travis/requests/services/receive/api.rb
+++ b/lib/travis/requests/services/receive/api.rb
@@ -42,7 +42,7 @@ module Travis
           def commit
             @commit ||= {
               commit:          commit_data['sha'],
-              message:         commit_data['commit']['message'],
+              message:         message,
               branch:          branch,
               ref:             nil,                                        # TODO verify that we do not need this
               committed_at:    commit_data['commit']['committer']['date'], # TODO in case of API requests we'd want to display the timestamp of the incoming request
@@ -66,6 +66,10 @@ module Travis
 
             def repo_data
               event['repository'] || {}
+            end
+
+            def message
+              event['message'] || commit_data['commit']['message']
             end
 
             def slug


### PR DESCRIPTION
This is just band aid atm. 

All of our domain models, our API, and our UI are all built around the idea that a request always comes from a git commit. With the request api this isn't true any more. 

Maybe it would make sense to change some of that that at some point, but for now, and for our internal usage we should be able to pass through a message so it is easier to spot in the UI (even though all the other bits, such as `commiter_name`, `commited_at` etc. do not make any sense).
