### PR TITLE
add pushover notification support

### DIFF
--- a/lib/travis/addons.rb
+++ b/lib/travis/addons.rb
@@ -14,6 +14,7 @@ module Travis
     require 'travis/addons/sqwiggle'
     require 'travis/addons/webhook'
     require 'travis/addons/slack'
+    require 'travis/addons/pushover'
 
     class << self
       def register

--- a/lib/travis/addons/README.markdown
+++ b/lib/travis/addons/README.markdown
@@ -12,5 +12,6 @@ The Addons are event handlers that accepts events such as "build finished" and f
 - Sqwiggle
 - States cache: Caches the state of each branch in Memcached for status images.
 - Webhook
+- Pushover
 
 To add a new notification service, an event handler and a task is needed. The event handler is run by [`travis-hub`](https://github.com/travis-ci/travis-hub) and has access to the database. This should check whether the event should be forwarded at all, and pull out any necessary configuration values. It should then asynchronously run the corresponding Task. The Task is run by [`travis-tasks`](https://github.com/travis-ci/travis-tasks) via Sidekiq and should do the actual API calls needed. The event handler should finish very quickly, while the task is allowed to take longer. 

--- a/lib/travis/addons/pushover.rb
+++ b/lib/travis/addons/pushover.rb
@@ -1,0 +1,13 @@
+module Travis
+  module Addons
+    module Pushover
+      module Instruments
+        require 'travis/addons/pushover/instruments'
+      end
+
+      require 'travis/addons/pushover/event_handler'
+
+      class Task < ::Travis::Task; end
+    end
+  end
+end

--- a/lib/travis/addons/pushover/event_handler.rb
+++ b/lib/travis/addons/pushover/event_handler.rb
@@ -1,0 +1,37 @@
+require 'travis/addons/pushover/instruments'
+require 'travis/event/handler'
+
+module Travis
+  module Addons
+    module Pushover
+
+      # Publishes a build notification to pushover users as defined in the
+      # configuration (`.travis.yml`).
+      #
+      # Credentials are encrypted using the repository's ssl key.
+      class EventHandler < Event::Handler
+        API_VERSION = 'v2'
+
+        EVENTS = /build:finished/
+
+        def handle?
+          !pull_request? && users.present? && api_key.present? && config.send_on_finished_for?(:pushover)
+        end
+
+        def handle
+          Travis::Addons::Pushover::Task.run(:pushover, payload, users: users, api_key: api_key)
+        end
+
+        def users
+          @users ||= config.notification_values(:pushover, :users)
+        end
+
+        def api_key
+          @api_key ||= config.notifications[:pushover][:api_key]
+        end
+
+        Instruments::EventHandler.attach_to(self)
+      end
+    end
+  end
+end

--- a/lib/travis/addons/pushover/instruments.rb
+++ b/lib/travis/addons/pushover/instruments.rb
@@ -1,0 +1,30 @@
+require 'travis/notification/instrument/event_handler'
+require 'travis/notification/instrument/task'
+
+module Travis
+  module Addons
+    module Pushover
+      module Instruments
+        class EventHandler < Notification::Instrument::EventHandler
+          def notify_completed
+            publish(:users => handler.users, :api_key => handler.api_key)
+          end
+        end
+
+        class Task < Notification::Instrument::Task
+          def run_completed
+            publish(
+              :msg => "for #<Build id=#{payload[:build][:id]}>",
+              :repository => payload[:repository][:slug],
+              :object_type => 'Build',
+              :object_id => payload[:build][:id],
+              :users => task.users,
+              :message => task.message,
+              :api_key => task.api_key
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/event/config.rb
+++ b/lib/travis/event/config.rb
@@ -4,9 +4,9 @@ module Travis
   module Event
     class Config
       DEFAULTS = {
-        start:   { email: false,   webhooks: false,   campfire: false,   hipchat: false,   irc: false,   flowdock: false, sqwiggle: false, slack: false },
-        success: { email: :change, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always },
-        failure: { email: :always, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always }
+        start:   { email: false,   webhooks: false,   campfire: false,   hipchat: false,   irc: false,   flowdock: false, sqwiggle: false, slack: false, pushover: false },
+        success: { email: :change, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, pushover: :always, },
+        failure: { email: :always, webhooks: :always, campfire: :always, hipchat: :always, irc: :always, flowdock: :always, sqwiggle: :always, slack: :always, pushover: :always, }
       }
 
       attr_reader :payload, :build, :secure_key, :config

--- a/spec/travis/addons/pushover/event_handler_spec.rb
+++ b/spec/travis/addons/pushover/event_handler_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+
+describe Travis::Addons::Pushover::EventHandler do
+  include Travis::Testing::Stubs
+
+  let(:subject) { Travis::Addons::Pushover::EventHandler }
+  let(:payload) { Travis::Api.data(build, for: 'event', version: 'v0') }
+
+  describe 'subscription' do
+    let(:handler) { subject.any_instance }
+
+    before :each do
+      Travis::Event.stubs(:subscribers).returns [:pushover]
+      handler.stubs(:handle => true, :handle? => true)
+      Travis::Api.stubs(:data).returns(stub('data'))
+    end
+
+    it 'build:started does not notify' do
+      handler.expects(:notify).never
+      Travis::Event.dispatch('build:started', build)
+    end
+
+    it 'build:finish notifies' do
+      handler.expects(:notify)
+      Travis::Event.dispatch('build:finished', build)
+    end
+  end
+
+  describe 'handler' do
+    let(:event) { 'build:finished' }
+    let(:task)  { Travis::Addons::Pushover::Task }
+
+    before :each do
+      build.stubs(:config => { :notifications => { :pushover => { :users => ['userone', 'usertwo'], :api_key => 'myapikey' } } })
+    end
+
+    def notify
+      subject.notify(event, build)
+    end
+
+    it 'passes ssl key from repository to config' do
+      config = stub('config', :notification_values => {})
+
+      Travis::Event::Config.expects(:new).with(payload, build.repository.key).
+        returns(config)
+      notify
+    end
+
+    it 'triggers a task if the build is a push request' do
+      build.stubs(:pull_request?).returns(false)
+      task.expects(:run).with(:pushover, payload, users: ['userone', 'usertwo'], api_key: 'myapikey')
+      notify
+    end
+
+    it 'does not trigger a task if the build is a pull request' do
+      build.stubs(:pull_request?).returns(true)
+      task.expects(:run).never
+      notify
+    end
+
+    it 'triggers a task if users and api_key are present' do
+      build.stubs(:config => { :notifications => { :pushover => { users: ['userone', 'usertwo'], api_key: 'myapikey' } } })
+      task.expects(:run).with(:pushover, payload, users: ['userone', 'usertwo'], api_key: 'myapikey')
+      notify
+    end
+
+    it 'does not trigger a task if no users are present' do
+      build.stubs(:config => { :notifications => { :pushover => { users: [], api_key: 'myapikey' } } })
+      task.expects(:run).never
+      notify
+    end
+
+    it 'does not trigger a task if no api_key is present' do
+      build.stubs(:config => { :notifications => { :pushover => { users: ['userone', 'usertwo'] } } })
+      task.expects(:run).never
+      notify
+    end
+
+    it 'triggers a task if specified by the config' do
+      Travis::Event::Config.any_instance.stubs(:send_on_finished_for?).with(:pushover).returns(true)
+      task.expects(:run).with(:pushover, payload, users: ['userone', 'usertwo'], api_key: 'myapikey')
+      notify
+    end
+
+    it 'does not trigger task if specified by the config' do
+      Travis::Event::Config.any_instance.stubs(:send_on_finished_for?).with(:pushover).returns(false)
+      task.expects(:run).never
+      notify
+    end
+  end
+
+  describe :users do
+    let(:handler) { subject.new('build:finished', build, {}, payload) }
+
+    it 'returns an array of user keys when given a string' do
+      users = 'only_one_user'
+      build.stubs(:config => { :notifications => { :pushover => users } })
+      handler.users.should == ['only_one_user']
+    end
+
+    it 'returns an array of user keys when given an array' do
+      users = ['only_one_user']
+      build.stubs(:config => { :notifications => { :pushover => users } })
+      handler.users.should == users
+    end
+
+    it 'returns an array of multiple user keys when given a comma separated string' do
+      users = 'userkeyA, userkeyB'
+      build.stubs(:config => { :notifications => { :pushover => users } })
+      handler.users.should == users.split(',').map(&:strip)
+    end
+
+    it 'returns an array of values if the build configuration specifies an array of user keys within a config hash' do
+      build.stubs(:config => { :notifications => { :pushover => { users: ['userkeyA', 'userkeyB'], on_success: 'change' } } })
+      handler.users.should == ['userkeyA', 'userkeyB']
+    end
+  end
+
+end

--- a/spec/travis/addons/pushover/instruments/event_handler_spec.rb
+++ b/spec/travis/addons/pushover/instruments/event_handler_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Travis::Addons::Pushover::Instruments::EventHandler do
+  include Travis::Testing::Stubs
+
+  let(:subject)   { Travis::Addons::Pushover::EventHandler }
+  let(:publisher) { Travis::Notification::Publisher::Memory.new }
+  let(:build)     { stub_build(config: { notifications: { pushover: { users: ['auser'], api_key: 'myapikey'} } }) }
+  let(:event)     { publisher.events[1] }
+
+  before :each do
+    Travis::Notification.publishers.replace([publisher])
+    subject.any_instance.stubs(:handle)
+    subject.notify('build:finished', build)
+  end
+
+  it 'publishes a event' do
+    event.should publish_instrumentation_event(
+      event: 'travis.addons.pushover.event_handler.notify:completed',
+      message: 'Travis::Addons::Pushover::EventHandler#notify:completed (build:finished) for #<Build id=1>',
+    )
+    event[:data].except(:payload).should == {
+      event: 'build:finished',
+      users: ['auser'],
+      api_key: 'myapikey',
+      repository: 'svenfuchs/minimal',
+      request_id: 1,
+      object_id: 1,
+      object_type: 'Build'
+    }
+    event[:data][:payload].should_not be_nil
+  end
+end


### PR DESCRIPTION
This adds support for notifications via Pushover ( https://pushover.net/ )

This CR is a companion to https://github.com/travis-ci/travis-tasks/pull/28 ; see that for most of my description and commentary.