### PR TITLE
automatically register services with their default name

### DIFF
--- a/lib/travis/enqueue/services/enqueue_jobs.rb
+++ b/lib/travis/enqueue/services/enqueue_jobs.rb
@@ -17,8 +17,6 @@ module Travis
 
         require 'travis/enqueue/services/enqueue_jobs/limit'
 
-        register :enqueue_jobs
-
         def self.run
           new.run
         end

--- a/lib/travis/services/base.rb
+++ b/lib/travis/services/base.rb
@@ -7,6 +7,10 @@ module Travis
         Travis.services.add(key, self)
       end
 
+      def self.inherited(subclass)
+        subclass.register(subclass.service_key)
+      end
+
       include Helpers
 
       attr_reader :current_user, :params
@@ -22,6 +26,12 @@ module Travis
 
       def logger
         Travis.logger
+      end
+
+      private
+
+      def self.service_key
+        self.name.split('::').last.underscore.to_sym
       end
     end
   end

--- a/lib/travis/services/cancel_build.rb
+++ b/lib/travis/services/cancel_build.rb
@@ -5,8 +5,6 @@ module Travis
     class CancelBuild < Base
       extend Travis::Instrumentation
 
-      register :cancel_build
-
       attr_reader :source
 
       def initialize(*)

--- a/lib/travis/services/cancel_job.rb
+++ b/lib/travis/services/cancel_job.rb
@@ -6,8 +6,6 @@ module Travis
     class CancelJob < Base
       extend Travis::Instrumentation
 
-      register :cancel_job
-
       attr_reader :source
 
       def initialize(*)

--- a/lib/travis/services/delete_caches.rb
+++ b/lib/travis/services/delete_caches.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class DeleteCaches < Base
-      register :delete_caches
-
       def run
         caches = run_service(:find_caches, params)
         caches.each { |c| c.s3_object.destroy }

--- a/lib/travis/services/find_admin.rb
+++ b/lib/travis/services/find_admin.rb
@@ -9,8 +9,6 @@ module Travis
       extend Travis::Instrumentation
       include Travis::Logging
 
-      register :find_admin
-
       def run
         if repository
           admin = candidates.first

--- a/lib/travis/services/find_annotations.rb
+++ b/lib/travis/services/find_annotations.rb
@@ -1,8 +1,6 @@
 module Travis
   module Services
     class FindAnnotations < Base
-      register :find_annotations
-
       def run
         if params[:ids]
           scope(:annotation).where(id: params[:ids])

--- a/lib/travis/services/find_branch.rb
+++ b/lib/travis/services/find_branch.rb
@@ -4,8 +4,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindBranch < Base
-      register :find_branch
-
       def run
         result
       end

--- a/lib/travis/services/find_branches.rb
+++ b/lib/travis/services/find_branches.rb
@@ -4,8 +4,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindBranches < Base
-      register :find_branches
-
       def run
         result
       end

--- a/lib/travis/services/find_build.rb
+++ b/lib/travis/services/find_build.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindBuild < Base
-      register :find_build
-
       def run(options = {})
         preload(result) if result
       end

--- a/lib/travis/services/find_builds.rb
+++ b/lib/travis/services/find_builds.rb
@@ -7,8 +7,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindBuilds < Base
-      register :find_builds
-
       def run
         preload(result)
       end

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -4,8 +4,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindCaches < Base
-      register :find_caches
-
       class Wrapper
         attr_reader :repository, :s3_object
 

--- a/lib/travis/services/find_daily_repos_stats.rb
+++ b/lib/travis/services/find_daily_repos_stats.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindDailyReposStats < Base
-      register :find_daily_repos_stats
-
       def run
         select scope(:repository).
           select(['date(created_at) AS date', 'count(created_at) AS count']).

--- a/lib/travis/services/find_daily_tests_stats.rb
+++ b/lib/travis/services/find_daily_tests_stats.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindDailyTestsStats < Base
-      register :find_daily_tests_stats
-
       def run
         select scope(:job).
           select(['date(created_at) AS date', 'count(created_at) AS count']).

--- a/lib/travis/services/find_hooks.rb
+++ b/lib/travis/services/find_hooks.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindHooks < Base
-      register :find_hooks
-
       def run
         current_user.service_hooks(params)
       end

--- a/lib/travis/services/find_job.rb
+++ b/lib/travis/services/find_job.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindJob < Base
-      register :find_job
-
       def run(options = {})
         preload(result) if result
       end

--- a/lib/travis/services/find_jobs.rb
+++ b/lib/travis/services/find_jobs.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindJobs < Base
-      register :find_jobs
-
       def run
         preload(result)
       end

--- a/lib/travis/services/find_log.rb
+++ b/lib/travis/services/find_log.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindLog < Base
-      register :find_log
-
       def run(options = {})
         result if result
       end

--- a/lib/travis/services/find_repo.rb
+++ b/lib/travis/services/find_repo.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindRepo < Base
-      register :find_repo
-
       def run(options = {})
         result
       end

--- a/lib/travis/services/find_repos.rb
+++ b/lib/travis/services/find_repos.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindRepos < Base
-      register :find_repos
-
       def run
         result
       end

--- a/lib/travis/services/find_request.rb
+++ b/lib/travis/services/find_request.rb
@@ -1,8 +1,6 @@
 module Travis
   module Services
     class FindRequest < Base
-      register :find_request
-
       def run(options = {})
         result
       end

--- a/lib/travis/services/find_requests.rb
+++ b/lib/travis/services/find_requests.rb
@@ -3,8 +3,6 @@ require 'core_ext/active_record/none_scope'
 module Travis
   module Services
     class FindRequests < Base
-      register :find_requests
-
       def run
         preload(result)
       end

--- a/lib/travis/services/find_user_accounts.rb
+++ b/lib/travis/services/find_user_accounts.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindUserAccounts < Base
-      register :find_user_accounts
-
       def run
         ([current_user] + orgs).map do |record|
           ::Account.from(record, :repos_count => repos_counts[record.login])

--- a/lib/travis/services/find_user_broadcasts.rb
+++ b/lib/travis/services/find_user_broadcasts.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindUserBroadcasts < Base
-      register :find_user_broadcasts
-
       def run
         Broadcast.by_user(current_user)
       end

--- a/lib/travis/services/find_user_permissions.rb
+++ b/lib/travis/services/find_user_permissions.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class FindUserPermissions < Base
-      register :find_user_permissions
-
       def run
         scope = current_user.permissions
         scope = scope.by_roles(params[:roles].to_s.split(',')) if params[:roles]

--- a/lib/travis/services/regenerate_repo_key.rb
+++ b/lib/travis/services/regenerate_repo_key.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class RegenerateRepoKey < Base
-      register :regenerate_repo_key
-
       def run(options = {})
         if repo && accept?
           regenerate

--- a/lib/travis/services/remove_log.rb
+++ b/lib/travis/services/remove_log.rb
@@ -4,8 +4,6 @@ module Travis
       extend Travis::Instrumentation
       include Travis::Logging
 
-      register :remove_log
-
       FORMAT = "Log removed by %s at %s"
 
       def run

--- a/lib/travis/services/reset_model.rb
+++ b/lib/travis/services/reset_model.rb
@@ -6,8 +6,6 @@ module Travis
     class ResetModel < Base
       extend Travis::Instrumentation
 
-      register :reset_model
-
       def run
         reset if target && accept?
         true

--- a/lib/travis/services/sync_user.rb
+++ b/lib/travis/services/sync_user.rb
@@ -4,8 +4,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class SyncUser < Base
-      register :sync_user
-
       def run
         trigger_sync unless user.syncing?
       end

--- a/lib/travis/services/update_annotation.rb
+++ b/lib/travis/services/update_annotation.rb
@@ -1,8 +1,6 @@
 module Travis
   module Services
     class UpdateAnnotation < Base
-      register :update_annotation
-
       def run
         if annotations_enabled? && annotation_provider
           cached_annotation = annotation

--- a/lib/travis/services/update_hook.rb
+++ b/lib/travis/services/update_hook.rb
@@ -6,8 +6,6 @@ module Travis
     class UpdateHook < Base
       extend Travis::Instrumentation
 
-      register :update_hook
-
       def run
         run_service(:github_set_hook, id: repo.id, active: active?)
         repo.update_column(:active, active?)

--- a/lib/travis/services/update_job.rb
+++ b/lib/travis/services/update_job.rb
@@ -7,8 +7,6 @@ module Travis
     class UpdateJob < Base
       extend Travis::Instrumentation
 
-      register :update_job
-
       EVENT = [:start, :finish, :reset]
 
       def run

--- a/lib/travis/services/update_log.rb
+++ b/lib/travis/services/update_log.rb
@@ -6,8 +6,6 @@ module Travis
     class UpdateLog < Base
       extend Travis::Instrumentation
 
-      register :update_log
-
       def run
         log = run_service(:find_log, id: params[:id])
         log.update_attributes(archived_at: params[:archived_at], archive_verified: params[:archive_verified]) if log

--- a/lib/travis/services/update_user.rb
+++ b/lib/travis/services/update_user.rb
@@ -3,8 +3,6 @@ require 'travis/services/base'
 module Travis
   module Services
     class UpdateUser < Base
-      register :update_user
-
       LOCALES = %w(en es fr ja nb nl pl pt-BR ru de) # TODO how to figure these out
 
       attr_reader :result


### PR DESCRIPTION
This cleans up the services a bit, which I thought was neat.

What I don't like though, is that the Github services are currently registered twice, once when inherited from base with their `service_key` name (without `github_` prepended) and then once when manually registered. Feel free to just close this based on that, or for not liking this approach in general :)