### PR TITLE
Add build/job :received state

### DIFF
--- a/db/migrate/20150121135400_jobs_add_received_at.rb
+++ b/db/migrate/20150121135400_jobs_add_received_at.rb
@@ -1,0 +1,5 @@
+class JobsAddReceivedAt < ActiveRecord::Migration
+  def change
+    add_column :jobs, :received_at, :datetime
+  end
+end

--- a/db/migrate/20150121135401_builds_add_received_at.rb
+++ b/db/migrate/20150121135401_builds_add_received_at.rb
@@ -1,0 +1,5 @@
+class BuildsAddReceivedAt < ActiveRecord::Migration
+  def change
+    add_column :builds, :received_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -261,7 +261,8 @@ CREATE TABLE builds (
     pull_request_number integer,
     branch character varying(255),
     canceled_at timestamp without time zone,
-    cached_matrix_ids integer[]
+    cached_matrix_ids integer[],
+    received_at timestamp without time zone
 );
 
 
@@ -383,7 +384,8 @@ CREATE TABLE jobs (
     owner_type character varying(255),
     result integer,
     queued_at timestamp without time zone,
-    canceled_at timestamp without time zone
+    canceled_at timestamp without time zone,
+    received_at timestamp without time zone
 );
 
 
@@ -453,7 +455,9 @@ CREATE TABLE logs (
     archiving boolean,
     archived_at timestamp without time zone,
     archive_verified boolean,
-    purged_at timestamp without time zone
+    purged_at timestamp without time zone,
+    removed_at timestamp without time zone,
+    removed_by integer
 );
 
 
@@ -1556,4 +1560,10 @@ INSERT INTO schema_migrations (version) VALUES ('20140210003014');
 
 INSERT INTO schema_migrations (version) VALUES ('20140210012509');
 
+INSERT INTO schema_migrations (version) VALUES ('20140612131826');
+
 INSERT INTO schema_migrations (version) VALUES ('20140827121945');
+
+INSERT INTO schema_migrations (version) VALUES ('20150121135400');
+
+INSERT INTO schema_migrations (version) VALUES ('20150121135401');

--- a/lib/travis/addons/pusher/event_handler.rb
+++ b/lib/travis/addons/pusher/event_handler.rb
@@ -8,8 +8,8 @@ module Travis
       # Notifies registered clients about various state changes through Pusher.
       class EventHandler < Event::Handler
         EVENTS = [
-          /^build:(created|started|finished|canceled)/,
-          /^job:test:(created|started|log|finished|canceled)/
+          /^build:(created|received|started|finished|canceled)/,
+          /^job:test:(created|received|started|log|finished|canceled)/
         ]
 
         attr_reader :channels

--- a/lib/travis/api/v0/pusher/build.rb
+++ b/lib/travis/api/v0/pusher/build.rb
@@ -5,9 +5,9 @@ module Travis
         class Build
           require 'travis/api/v0/pusher/build/canceled'
           require 'travis/api/v0/pusher/build/created'
+          require 'travis/api/v0/pusher/build/received'
           require 'travis/api/v0/pusher/build/started'
           require 'travis/api/v0/pusher/build/finished'
-
 
           include Formats
 

--- a/lib/travis/api/v0/pusher/build/received.rb
+++ b/lib/travis/api/v0/pusher/build/received.rb
@@ -1,0 +1,12 @@
+module Travis
+  module Api
+    module V0
+      module Pusher
+        class Build
+          class Received < Build
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v0/pusher/build/received/job.rb
+++ b/lib/travis/api/v0/pusher/build/received/job.rb
@@ -1,0 +1,47 @@
+module Travis
+  module Api
+    module V0
+      module Pusher
+        class Build
+          class Received < Build
+            class Job
+              include Formats, V1::Helpers::Legacy
+
+              attr_reader :job, :commit
+
+              def initialize(job)
+                @job = job
+                @commit = job.commit
+              end
+
+              def data
+                {
+                  'id' => job.id,
+                  'repository_id' => job.repository_id,
+                  'repository_private' => repository.private,
+                  'parent_id' => job.source_id,
+                  'number' => job.number,
+                  'state' => job.state.to_s,
+                  'result' => legacy_job_result(job),
+                  'config' => job.obfuscated_config,
+                  'commit' => commit.commit,
+                  'branch' => commit.branch,
+                  'message' => commit.message,
+                  'compare_url' => commit.compare_url,
+                  'started_at' => format_date(job.started_at),
+                  'finished_at' => format_date(job.finished_at),
+                  'committed_at' => format_date(commit.committed_at),
+                  'author_name' => commit.author_name,
+                  'author_email' => commit.author_email,
+                  'committer_name' => commit.committer_name,
+                  'committer_email' => commit.committer_email,
+                  'allow_failure' => job.allow_failure
+                }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v0/pusher/job.rb
+++ b/lib/travis/api/v0/pusher/job.rb
@@ -6,6 +6,7 @@ module Travis
           require 'travis/api/v0/pusher/job/canceled'
           require 'travis/api/v0/pusher/job/created'
           require 'travis/api/v0/pusher/job/log'
+          require 'travis/api/v0/pusher/job/received'
           require 'travis/api/v0/pusher/job/started'
           require 'travis/api/v0/pusher/job/finished'
 

--- a/lib/travis/api/v0/pusher/job/received.rb
+++ b/lib/travis/api/v0/pusher/job/received.rb
@@ -1,0 +1,12 @@
+module Travis
+  module Api
+    module V0
+      module Pusher
+        class Job
+          class Received < Job
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/enqueue/services/enqueue_jobs.rb
+++ b/lib/travis/enqueue/services/enqueue_jobs.rb
@@ -54,6 +54,7 @@ module Travis
                   limit = nil
                   queueable = nil
                   Metriks.timer('enqueue.limit_per_owner').time do
+                    Travis.logger.info "About to evaluate jobs for: #{owner.login}."
                     limit = Limit.new(owner, jobs)
                     queueable = limit.queueable
                   end
@@ -91,7 +92,9 @@ module Travis
 
           def jobs
             Metriks.timer('enqueue.fetch_jobs').time do
-              Job.includes(:owner).queueable.all
+              jobs = Job.includes(:owner).queueable.all
+              Travis.logger.info "Found #{jobs.size} jobs in total." if jobs.size > 0
+              jobs
             end
           end
 

--- a/lib/travis/model/build/states.rb
+++ b/lib/travis/model/build/states.rb
@@ -21,17 +21,22 @@ class Build
     included do
       include SimpleStates
 
-      states :created, :started, :passed, :failed, :errored, :canceled
+      states :created, :received, :started, :passed, :failed, :errored, :canceled
 
-      event :start,  to: :started,  unless: [:started?, :failed?, :errored?]
-      event :finish, to: :finished, if: :should_finish?
-      event :reset,  to: :created
-      event :cancel, to: :canceled, if: :cancelable?
+      event :receive, to: :received,  unless: [:received?, :started?, :failed?, :errored?]
+      event :start,   to: :started,   unless: [:started?, :failed?, :errored?]
+      event :finish,  to: :finished, if: :should_finish?
+      event :reset,   to: :created
+      event :cancel,  to: :canceled, if: :cancelable?
       event :all, after: [:denormalize, :notify]
     end
 
     def should_finish?
       matrix_finished? && !finished?
+    end
+
+    def receive(data = {})
+      self.received_at = data[:received_at]
     end
 
     def start(data = {})

--- a/lib/travis/services/update_job.rb
+++ b/lib/travis/services/update_job.rb
@@ -9,7 +9,7 @@ module Travis
 
       register :update_job
 
-      EVENT = [:start, :finish, :reset]
+      EVENT = [:receive, :start, :finish, :reset]
 
       def run
         if job.canceled? && event != :reset

--- a/spec/support/payloads.rb
+++ b/spec/support/payloads.rb
@@ -589,13 +589,14 @@ GITHUB_OAUTH_DATA = {
 }
 
 WORKER_PAYLOADS = {
-  'job:test:start'  => { 'id' => 1, 'state' => 'started',  'started_at'  => '2011-01-01 00:02:00 +0200', 'worker' => 'ruby3.worker.travis-ci.org:travis-ruby-4' },
-  'job:test:log'    => { 'id' => 1, 'log' => '... appended' },
-  'job:test:log:1'  => { 'id' => 1, 'log' => 'the '  },
-  'job:test:log:2'  => { 'id' => 1, 'log' => 'full ' },
-  'job:test:log:3'  => { 'id' => 1, 'log' => 'log'   },
-  'job:test:finish' => { 'id' => 1, 'state' => 'passed', 'finished_at' => '2011-01-01 00:03:00 +0200', 'log' => 'the full log' },
-  'job:test:reset'  => { 'id' => 1 }
+  'job:test:receive' => { 'id' => 1, 'state' => 'received',  'received_at'  => '2011-01-01 00:02:00 +0200', 'worker' => 'ruby3.worker.travis-ci.org:travis-ruby-4' },
+  'job:test:start'   => { 'id' => 1, 'state' => 'started',  'started_at'  => '2011-01-01 00:02:00 +0200', 'worker' => 'ruby3.worker.travis-ci.org:travis-ruby-4' },
+  'job:test:log'     => { 'id' => 1, 'log' => '... appended' },
+  'job:test:log:1'   => { 'id' => 1, 'log' => 'the '  },
+  'job:test:log:2'   => { 'id' => 1, 'log' => 'full ' },
+  'job:test:log:3'   => { 'id' => 1, 'log' => 'log'   },
+  'job:test:finish'  => { 'id' => 1, 'state' => 'passed', 'finished_at' => '2011-01-01 00:03:00 +0200', 'log' => 'the full log' },
+  'job:test:reset'   => { 'id' => 1 }
 }
 
 WORKER_LEGACY_PAYLOADS = {

--- a/spec/travis/model/build/states_spec.rb
+++ b/spec/travis/model/build/states_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 class BuildMock
   include Build::States
   class << self; def name; 'Build'; end; end
-  attr_accessor :state, :started_at, :finished_at, :duration
+  attr_accessor :state, :received_at, :started_at, :finished_at, :duration
   def denormalize(*); end
 end
 
@@ -46,6 +46,59 @@ describe Build::States do
         build.stubs(matrix: [stub(state: :passed)])
         build.reset
         build.state.should == :created
+      end
+    end
+
+    describe 'receive' do
+      let(:data) { WORKER_PAYLOADS['job:test:receive'] }
+
+      it 'does not denormalize attributes' do
+        build.denormalize?('job:test:receive').should be_false
+      end
+
+      describe 'when the build is not already received' do
+        it 'sets the state to :received' do
+          build.receive(data)
+          build.state.should == :received
+        end
+
+        it 'notifies observers' do
+          Travis::Event.expects(:dispatch).with('build:received', build, data)
+          build.receive(data)
+        end
+      end
+
+      describe 'when the build is already received' do
+        before :each do
+          build.state = :received
+        end
+
+        it 'does not notify observers' do
+          Travis::Event.expects(:dispatch).never
+          build.receive(data)
+        end
+      end
+
+      describe 'when the build has failed' do
+        before :each do
+          build.state = :failed
+        end
+
+        it 'does not notify observers' do
+          Travis::Event.expects(:dispatch).never
+          build.receive(data)
+        end
+      end
+
+      describe 'when the build has errored' do
+        before :each do
+          build.state = :errored
+        end
+
+        it 'does not notify observers' do
+          Travis::Event.expects(:dispatch).never
+          build.receive(data)
+        end
       end
     end
 


### PR DESCRIPTION
Tested on Enterprise, needs to be bumped in hub. Should be good to be merged once web doesn't raise errors on `build:received` and `job:received` messages.

Note: this adds migrations