### PR TITLE
Exclude config blobs on demand for Job and Build

### DIFF
--- a/lib/travis/services/find_build.rb
+++ b/lib/travis/services/find_build.rb
@@ -6,7 +6,7 @@ module Travis
       register :find_build
 
       def run(options = {})
-        options[:include_config] ||= false
+        options[:exclude_config] ||= false
         preload(result(options)) if result(options)
       end
 
@@ -38,9 +38,9 @@ module Travis
 
         def load_result(options = {})
           columns = scope(:build).column_names
-          columns -= %w(config) unless options[:include_config]
+          columns -= %w(config) if options[:exclude_config]
           scope(:build).select(columns).find_by_id(params[:id]).tap do |res|
-            res.config = {} unless options[:include_config]
+            res.config = {} if options[:exclude_config]
           end
         end
 

--- a/lib/travis/services/find_build.rb
+++ b/lib/travis/services/find_build.rb
@@ -6,7 +6,8 @@ module Travis
       register :find_build
 
       def run(options = {})
-        preload(result) if result
+        options[:include_config] ||= false
+        preload(result(options)) if result(options)
       end
 
       def final?
@@ -31,8 +32,16 @@ module Travis
           end
         end
 
-        def result
-          @result ||= scope(:build).find_by_id(params[:id])
+        def result(options = {})
+          @result ||= load_result(options)
+        end
+
+        def load_result(options = {})
+          columns = scope(:build).column_names
+          columns -= %w(config) unless options[:include_config]
+          scope(:build).select(columns).find_by_id(params[:id]).tap do |res|
+            res.config = {} unless options[:include_config]
+          end
         end
 
         def preload(build)

--- a/lib/travis/services/find_job.rb
+++ b/lib/travis/services/find_job.rb
@@ -6,7 +6,8 @@ module Travis
       register :find_job
 
       def run(options = {})
-        preload(result) if result
+        options[:include_config] ||= false
+        preload(result(options)) if result(options)
       end
 
       def final?
@@ -21,11 +22,19 @@ module Travis
 
       private
 
-        def result
-          @result ||= scope(:job).find_by_id(params[:id])
+        def result(options = {})
+          @result ||= load_result(options)
         rescue ActiveRecord::SubclassNotFound => e
           Travis.logger.warn "[services:find-job] #{e.message}"
           raise ActiveRecord::RecordNotFound
+        end
+
+        def load_result(options = {})
+          columns = scope(:job).column_names
+          columns -= %w(config) unless options[:include_config]
+          scope(:job).select(columns).find_by_id(params[:id]).tap do |res|
+            res.config = {} unless options[:include_config]
+          end
         end
 
         def preload(job)

--- a/lib/travis/services/find_job.rb
+++ b/lib/travis/services/find_job.rb
@@ -6,7 +6,7 @@ module Travis
       register :find_job
 
       def run(options = {})
-        options[:include_config] ||= false
+        options[:exclude_config] ||= false
         preload(result(options)) if result(options)
       end
 
@@ -31,9 +31,9 @@ module Travis
 
         def load_result(options = {})
           columns = scope(:job).column_names
-          columns -= %w(config) unless options[:include_config]
+          columns -= %w(config) if options[:exclude_config]
           scope(:job).select(columns).find_by_id(params[:id]).tap do |res|
-            res.config = {} unless options[:include_config]
+            res.config = {} if options[:exclude_config]
           end
         end
 

--- a/spec/travis/services/find_build_spec.rb
+++ b/spec/travis/services/find_build_spec.rb
@@ -18,12 +18,12 @@ describe Travis::Services::FindBuild do
       lambda { service.run }.should_not raise_error
     end
 
-    it 'excludes config by default' do
-      service.run.config.should_not include(:sudo)
+    it 'includes config by default' do
+      service.run.config.should include(:sudo)
     end
 
-    it 'includes config when requested' do
-      service.run(include_config: true).config.should include(:sudo)
+    it 'excludes config when requested' do
+      service.run(exclude_config: true).config.should_not include(:sudo)
     end
   end
 

--- a/spec/travis/services/find_build_spec.rb
+++ b/spec/travis/services/find_build_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Travis::Services::FindBuild do
   include Support::ActiveRecord
 
-  let(:repo)    { Factory(:repository, :owner_name => 'travis-ci', :name => 'travis-core') }
-  let!(:build)  { Factory(:build, :repository => repo, :state => :finished, :number => 1) }
-  let(:params)  { { :id => build.id } }
+  let(:repo)    { Factory(:repository, owner_name: 'travis-ci', name: 'travis-core') }
+  let!(:build)  { Factory(:build, repository: repo, state: :finished, number: 1, config: {'sudo' => false}) }
+  let(:params)  { { id: build.id } }
   let(:service) { described_class.new(stub('user'), params) }
 
   describe 'run' do
@@ -16,6 +16,14 @@ describe Travis::Services::FindBuild do
     it 'does not raise if the build could not be found' do
       @params = { :id => build.id + 1 }
       lambda { service.run }.should_not raise_error
+    end
+
+    it 'excludes config by default' do
+      service.run.config.should_not include(:sudo)
+    end
+
+    it 'includes config when requested' do
+      service.run(include_config: true).config.should include(:sudo)
     end
   end
 

--- a/spec/travis/services/find_job_spec.rb
+++ b/spec/travis/services/find_job_spec.rb
@@ -4,7 +4,7 @@ describe Travis::Services::FindJob do
   include Support::ActiveRecord
 
   let(:repo)    { Factory(:repository) }
-  let!(:job)    { Factory(:test, repository: repo, state: :created, queue: 'builds.linux') }
+  let!(:job)    { Factory(:test, repository: repo, state: :created, queue: 'builds.linux', config: {'sudo' => false}) }
   let(:params)  { { id: job.id } }
   let(:service) { described_class.new(stub('user'), params) }
 
@@ -20,10 +20,21 @@ describe Travis::Services::FindJob do
     end
 
     it 'raises RecordNotFound if a SubclassNotFound error is raised during find' do
-      find_by_id = stub
-      find_by_id.stubs(:find_by_id).raises(ActiveRecord::SubclassNotFound)
+      find_by_id = stub.tap do |s|
+        s.stubs(:column_names).returns(%w(id config))
+        s.stubs(:select).returns(s)
+        s.stubs(:find_by_id).raises(ActiveRecord::SubclassNotFound)
+      end
       service.stubs(:scope).returns(find_by_id)
       lambda { service.run }.should raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'excludes config by default' do
+      service.run.config.should_not include(:sudo)
+    end
+
+    it 'includes config when requested' do
+      service.run(include_config: true).config.should include(:sudo)
     end
   end
 

--- a/spec/travis/services/find_job_spec.rb
+++ b/spec/travis/services/find_job_spec.rb
@@ -29,12 +29,12 @@ describe Travis::Services::FindJob do
       lambda { service.run }.should raise_error(ActiveRecord::RecordNotFound)
     end
 
-    it 'excludes config by default' do
-      service.run.config.should_not include(:sudo)
+    it 'includes config by default' do
+      service.run.config.should include(:sudo)
     end
 
-    it 'includes config when requested' do
-      service.run(include_config: true).config.should include(:sudo)
+    it 'excludes config when requested' do
+      service.run(exclude_config: true).config.should_not include(:sudo)
     end
   end
 


### PR DESCRIPTION
to cut down on database and network load.