### PR TITLE
Introduce `dist` as a possible key to be used for queue selection

### DIFF
--- a/lib/travis/model/job/queue.rb
+++ b/lib/travis/model/job/queue.rb
@@ -17,12 +17,13 @@ class Job
         sudo       = job.config[:sudo]
         owner      = job.repository.try(:owner)
         education  = Travis::Github::Education.education_queue?(owner)
-        queues.detect { |queue| queue.send(:matches?, owner_name, repo_name, language, os, sudo, education) } || default
+        dist       = job.config[:dist]
+        queues.detect { |queue| queue.send(:matches?, owner_name, repo_name, language, os, sudo, education, dist) } || default
       end
 
       def queues
         @queues ||= Array(Travis.config.queues).compact.map do |queue|
-          Queue.new(*queue.values_at(*[:queue, :slug, :owner, :language, :os, :sudo, :education]))
+          Queue.new(*queue.values_at(*[:queue, :slug, :owner, :language, :os, :sudo, :education, :dist]))
         end
       end
 
@@ -31,18 +32,18 @@ class Job
       end
     end
 
-    attr_reader :name, :slug, :owner, :language, :os, :sudo, :education
+    attr_reader :name, :slug, :owner, :language, :os, :sudo, :education, :dist
 
     protected
 
       def initialize(*args)
-        @name, @slug, @owner, @language, @os, @sudo, @education = *args
+        @name, @slug, @owner, @language, @os, @sudo, @education, @dist = *args
       end
 
-      def matches?(owner, repo_name, language, os = nil, sudo = nil, education = false)
+      def matches?(owner, repo_name, language, os = nil, sudo = nil, education = false, dist = nil)
         return matches_education?(education) if education
         matches_slug?("#{owner}/#{repo_name}") || matches_owner?(owner) ||
-          matches_os?(os) || matches_language?(language) || matches_sudo?(sudo)
+          matches_os?(os) || matches_language?(language) || matches_sudo?(sudo) || matches_dist?(dist)
       end
 
       def queue
@@ -71,6 +72,10 @@ class Job
 
       def matches_education?(education)
         !!self.education && (self.education == education)
+      end
+
+      def matches_dist?(dist)
+        !!self.dist && (self.dist == dist)
       end
   end
 end

--- a/spec/travis/model/job/queue_spec.rb
+++ b/spec/travis/model/job/queue_spec.rb
@@ -14,6 +14,7 @@ describe 'Job::Queue' do
       { :queue => 'builds.cloudfoundry', :owner => 'cloudfoundry' },
       { :queue => 'builds.clojure', :language => 'clojure' },
       { :queue => 'builds.erlang', :language => 'erlang' },
+      { :queue => 'builds.openstack', :dist => 'trusty' },
     ]
     Job::Queue.instance_variable_set(:@queues, nil)
     Job::Queue.instance_variable_set(:@default, nil)
@@ -170,6 +171,16 @@ describe 'Job::Queue' do
     it 'returns false when sudo is nil' do
       queue = queue('builds.docker', nil, nil, nil, nil, false)
       queue.send(:matches?, nil, nil, nil, nil, nil).should be_false
+    end
+
+    it 'returns true when dist matches' do
+      queue = queue('builds.openstack', nil, nil, nil, nil, false, 'trusty')
+      queue.send(:matches?, nil, nil, nil, nil, true, 'trusty').should be_true
+    end
+
+    it 'returns false when dist does not match' do
+      queue = queue('builds.docker', nil, nil, nil, nil, false, 'precise')
+      queue.send(:matches?, nil, nil, nil, nil, nil, 'trusty').should be_false
     end
   end
 end


### PR DESCRIPTION
The intention here is to use `dist: trusty` (or similar) for queue
selection, so that we can safely deploy a test queue, and enable
feature flips for controlled testing.