### PR TITLE
Add more job queue matchers

### DIFF
--- a/lib/travis/model/job/queue.rb
+++ b/lib/travis/model/job/queue.rb
@@ -70,6 +70,7 @@ class Job
         :language => Array(job.config[:language]).flatten.compact.first,
         :sudo => job.config.fetch(:sudo) { !repo_is_default_docker?(job) },
         :dist => job.config[:dist],
+        :osx_image => job.config[:osx_image],
       }
     end
 

--- a/lib/travis/model/job/queue.rb
+++ b/lib/travis/model/job/queue.rb
@@ -57,7 +57,15 @@ class Job
 
     def matches?(job)
       matchers = matchers_for(job)
-      @attrs.length > 0 && @attrs.all? { |key, value| matchers[key.to_sym] === value }
+
+      unknown_matchers = @attrs.keys - matchers.keys
+      if unknown_matchers.length > 0
+        warn "unknown matchers used for queue #{name}: #{unknown_matchers.join(", ")}"
+      end
+
+      known_matchers = @attrs.keys & matchers.keys
+
+      known_matchers.length > 0 && known_matchers.all? { |key| matchers[key.to_sym] === @attrs[key] }
     end
 
     private

--- a/lib/travis/model/job/queue.rb
+++ b/lib/travis/model/job/queue.rb
@@ -70,7 +70,6 @@ class Job
         :language => Array(job.config[:language]).flatten.compact.first,
         :sudo => job.config.fetch(:sudo) { !repo_is_default_docker?(job) },
         :dist => job.config[:dist],
-        :education => Travis::Github::Education.education_queue?(job.repository.try(:owner)),
       }
     end
 

--- a/spec/travis/model/job/queue_spec.rb
+++ b/spec/travis/model/job/queue_spec.rb
@@ -13,7 +13,6 @@ describe 'Job::Queue' do
       { :queue => 'builds.rails', :slug => 'rails/rails' },
       { :queue => 'builds.mac_osx', :os => 'osx' },
       { :queue => 'builds.docker', :sudo => false },
-      { :queue => 'builds.education', :education => true },
       { :queue => 'builds.cloudfoundry', :owner => 'cloudfoundry' },
       { :queue => 'builds.clojure', :language => 'clojure' },
       { :queue => 'builds.erlang', :language => 'erlang' },
@@ -192,16 +191,13 @@ describe 'Job::Queue' do
 
   describe 'Queue.queues' do
     it 'returns an array of Queues for the config hash' do
-      rails, os, docker, edu, cloudfoundry, clojure, erlang = Job::Queue.send(:queues)
+      rails, os, docker, cloudfoundry, clojure, erlang = Job::Queue.send(:queues)
 
       rails.name.should == 'builds.rails'
       rails.attrs[:slug].should == 'rails/rails'
 
       docker.name.should == 'builds.docker'
       docker.attrs[:sudo].should == false
-
-      edu.name.should == 'builds.education'
-      edu.attrs[:education].should == true
 
       cloudfoundry.name.should == 'builds.cloudfoundry'
       cloudfoundry.attrs[:owner].should == 'cloudfoundry'

--- a/spec/travis/model/job/queue_spec.rb
+++ b/spec/travis/model/job/queue_spec.rb
@@ -258,6 +258,16 @@ describe 'Job::Queue' do
       queue.matches?(stub('job', repository: stub('repository', owner_name: nil, name: nil, owner: nil), config: { dist: 'trusty' })).should be_false
     end
 
+    it 'returns true when osx_image matches' do
+      queue = queue('builds.mac_beta', { osx_image: 'beta' })
+      queue.matches?(stub('job', repository: stub('repository', owner_name: nil, name: nil, owner: nil), config: { osx_image: 'beta' })).should be_true
+    end
+
+    it 'returns false when osx_image does not match' do
+      queue = queue('builds.mac_stable', { osx_image: 'stable' })
+      queue.matches?(stub('job', repository: stub('repository', owner_name: nil, name: nil, owner: nil), config: { osx_image: 'beta' })).should be_false
+    end
+
     it 'returns false if no valid matchers are specified' do
       queue = queue('builds.invalid', { foobar_donotmatch: true })
       queue.matches?(stub('job', repository: stub('repository', owner_name: nil, name: nil, owner: nil), config: {})).should be_false

--- a/spec/travis/model/job/queue_spec.rb
+++ b/spec/travis/model/job/queue_spec.rb
@@ -257,5 +257,10 @@ describe 'Job::Queue' do
       queue = queue('builds.docker', { dist: 'precise' })
       queue.matches?(stub('job', repository: stub('repository', owner_name: nil, name: nil, owner: nil), config: { dist: 'trusty' })).should be_false
     end
+
+    it 'returns false if no valid matchers are specified' do
+      queue = queue('builds.invalid', { foobar_donotmatch: true })
+      queue.matches?(stub('job', repository: stub('repository', owner_name: nil, name: nil, owner: nil), config: {})).should be_false
+    end
   end
 end


### PR DESCRIPTION
This has a few minor cleanup things from my previous PR:

- Remove the `education` queue matcher, it's no longer needed.
- Test that if there are no valid matchers, things behave correctly (nothing matches an empty configuration). This is the previous behaviour, I just added a spec to ensure it doesn't change
- Only check the matchers that we know about, and print warnings if queue configs use unknown matchers.

Also, this adds an `osx_image` matcher for routing jobs based on the `osx_image` config setting (which is feature flagged).