### PR TITLE
add lower case indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage/
 # linked into db/migrate when following the setup instructions in
 # README.md.
 db/migrate/20140612131826_add_removed_info_to_logs.rb
+db/schema.rb

--- a/db/migrate/20150414001337_add_lower_case_indices.rb
+++ b/db/migrate/20150414001337_add_lower_case_indices.rb
@@ -1,0 +1,26 @@
+class AddLowerCaseIndices < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def up
+    add_lower_index :organizations, :login
+    add_lower_index :users,         :login
+    add_lower_index :repositories,  :name
+    add_lower_index :repositories,  :owner_name
+  end
+
+  def down
+    drop_lower_index :organizations, :login
+    drop_lower_index :users,         :login
+    drop_lower_index :repositories,  :name
+    drop_lower_index :repositories,  :owner_name
+  end
+
+  def add_lower_index(table, field)
+    drop_lower_index(table, field)
+    execute "CREATE INDEX CONCURRENTLY index_#{table}_on_lower_#{field} ON #{table} USING btree(lower(#{field}))"
+  end
+
+  def drop_lower_index(table, field)
+    execute "DROP INDEX IF EXISTS index_#{table}_on_lower_#{field}"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1300,6 +1300,13 @@ CREATE INDEX index_organizations_on_login ON organizations USING btree (login);
 
 
 --
+-- Name: index_organizations_on_lower_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_organizations_on_lower_login ON organizations USING btree (lower((login)::text));
+
+
+--
 -- Name: index_permissions_on_repository_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1332,6 +1339,20 @@ CREATE UNIQUE INDEX index_repositories_on_github_id ON repositories USING btree 
 --
 
 CREATE INDEX index_repositories_on_last_build_started_at ON repositories USING btree (last_build_started_at);
+
+
+--
+-- Name: index_repositories_on_lower_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_repositories_on_lower_name ON repositories USING btree (lower((name)::text));
+
+
+--
+-- Name: index_repositories_on_lower_owner_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_repositories_on_lower_owner_name ON repositories USING btree (lower((owner_name)::text));
 
 
 --
@@ -1416,6 +1437,13 @@ CREATE UNIQUE INDEX index_users_on_github_id ON users USING btree (github_id);
 --
 
 CREATE INDEX index_users_on_login ON users USING btree (login);
+
+
+--
+-- Name: index_users_on_lower_login; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_users_on_lower_login ON users USING btree (lower((login)::text));
 
 
 --
@@ -1728,3 +1756,5 @@ INSERT INTO schema_migrations (version) VALUES ('20150317004600');
 INSERT INTO schema_migrations (version) VALUES ('20150317020321');
 
 INSERT INTO schema_migrations (version) VALUES ('20150317080321');
+
+INSERT INTO schema_migrations (version) VALUES ('20150414001337');


### PR DESCRIPTION
Adds lower case indices for for organizations.login, users.login, repositories.name and repositories.owner_name.

This way we can easily implement case insensitive APIs and UIs.

See travis-ci/travis-ci#3198, travis-ci/travis-ci#1545, travis-ci/travis-ci#2334, travis-pro/travis-admin#48, travis-pro/team-teal#81.