### PR TITLE
Coerce `Resporitoy#regenerate_key!` to really regenerate the key

### DIFF
--- a/lib/travis/model/repository.rb
+++ b/lib/travis/model/repository.rb
@@ -157,7 +157,7 @@ class Repository < Travis::Model
 
   def regenerate_key!
     ActiveRecord::Base.transaction do
-      key.destroy
+      key.destroy unless key.nil?
       build_key
       save!
     end


### PR DESCRIPTION
Unfortunately, we ended up with a few thousand repositories
without SSL key, because we changed the way Repository models
are instantiated.
(Basically, we bypassed the ActiveRecord hooks to generate them.)

There is no simple way to force key regeneration at the moment,
so we brute force the key generation by going into the console,
select the suspect Repositories and call `#regenerate_key!`
on them.