### PR TITLE
Send repository.default_branch to the worker

### DIFF
--- a/lib/travis/api/v0/worker/job/test.rb
+++ b/lib/travis/api/v0/worker/job/test.rb
@@ -60,7 +60,8 @@ module Travis
                 'last_build_finished_at' => format_date(repository.last_build_finished_at),
                 'last_build_duration' => repository.last_build_duration,
                 'last_build_state' => repository.last_build_state.to_s,
-                'description' => repository.description
+                'description' => repository.description,
+                'default_branch' => repository.default_branch
               }
             end
 

--- a/lib/travis/testing/stubs.rb
+++ b/lib/travis/testing/stubs.rb
@@ -61,6 +61,7 @@ module Travis
           builds_only_with_travis_yml?: false,
           settings: stub_settings,
           users_with_permission: [],
+          default_branch: 'master'
         )
       end
       alias stub_repository stub_repo

--- a/spec/travis/api/v0/worker/job/test_spec.rb
+++ b/spec/travis/api/v0/worker/job/test_spec.rb
@@ -94,7 +94,8 @@ describe Travis::Api::V0::Worker::Job::Test do
         'last_build_duration' => 60,
         'last_build_state' => 'passed',
         'description' => 'the repo description',
-        'github_id' => 549743
+        'github_id' => 549743,
+        'default_branch' => 'master'
       }
     end
 
@@ -189,7 +190,8 @@ describe Travis::Api::V0::Worker::Job::Test do
         'last_build_duration' => 60,
         'last_build_state' => 'passed',
         'description' => 'the repo description',
-        'github_id' => 549743
+        'github_id' => 549743,
+        'default_branch' => 'master'
       }
     end
   end


### PR DESCRIPTION
Currently we don't send default_branch to the worker, so it doesn't have
a knowledge on what branch to use by default, for example for caching.