### PR TITLE
change to using connection.transaction

### DIFF
--- a/lib/travis/requests/services/receive.rb
+++ b/lib/travis/requests/services/receive.rb
@@ -58,9 +58,9 @@ module Travis
             return yield unless payload.repository
             result = nil
             Travis::AdvisoryLocks.exclusive("receive-repo:#{payload.repository[:github_id]}", 300) do
-              ActiveRecord::Base.connection.begin_db_transaction
-              result = yield
-              ActiveRecord::Base.connection.commit_db_transaction
+              ActiveRecord::Base.connection.transaction do
+                result = yield
+              end
             end
             result
           rescue => e


### PR DESCRIPTION
this way ActiveRecord is smart about knowing if a transaction is already created or not

removes warnings, and potentially bad side effects where a transaction is committed early