### PR TITLE
Accept multiple event types to Build.by_event_type

### DIFF
--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -83,12 +83,14 @@ class Build < Travis::Model
       pushes.where(branch.present? ? ['branch IN (?)', normalize_to_array(branch)] : [])
     end
 
-    def by_event_type(event_type)
-      event_type == 'pull_request' ?  pull_requests : pushes
+    def by_event_type(event_types)
+      event_types = Array(event_types).flatten
+      event_types << 'push' if event_types.empty?
+      where(event_type: event_types)
     end
 
     def pushes
-      where(:event_type => 'push')
+      where(event_type: 'push')
     end
 
     def pull_requests

--- a/spec/travis/services/find_builds_spec.rb
+++ b/spec/travis/services/find_builds_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Travis::Services::FindBuilds do
   include Support::ActiveRecord
 
-  let(:repo)    { Factory(:repository, :owner_name => 'travis-ci', :name => 'travis-core') }
-  let!(:build)  { Factory(:build, :repository => repo, :state => :finished, :number => 1) }
+  let(:repo)    { Factory(:repository, owner_name: 'travis-ci', name: 'travis-core') }
+  let!(:push)   { Factory(:build, repository: repo, event_type: 'push', state: :finished, number: 1) }
   let(:service) { described_class.new(stub('user'), params) }
 
   attr_reader :params
@@ -12,24 +12,24 @@ describe Travis::Services::FindBuilds do
   describe 'run' do
     it 'finds recent builds when empty params given' do
       @params = { :repository_id => repo.id }
-      service.run.should == [build]
+      service.run.should == [push]
     end
 
     it 'finds recent builds when no repo given' do
       @params = nil
-      service.run.should == [build]
+      service.run.should == [push]
     end
 
     it 'finds builds older than the given number' do
       @params = { :repository_id => repo.id, :after_number => 2 }
-      service.run.should == [build]
+      service.run.should == [push]
     end
 
     it 'finds builds with a given number, scoped by repository' do
       @params = { :repository_id => repo.id, :number => 1 }
       Factory(:build, :repository => Factory(:repository), :state => :finished, :number => 1)
       Factory(:build, :repository => repo, :state => :finished, :number => 2)
-      service.run.should == [build]
+      service.run.should == [push]
     end
 
     it 'does not find by number if repository_id is missing' do
@@ -40,7 +40,7 @@ describe Travis::Services::FindBuilds do
     it 'scopes to the given repository_id' do
       @params = { :repository_id => repo.id }
       Factory(:build, :repository => Factory(:repository), :state => :finished)
-      service.run.should == [build]
+      service.run.should == [push]
     end
 
     it 'returns an empty build scope when the repository could not be found' do
@@ -49,16 +49,32 @@ describe Travis::Services::FindBuilds do
     end
 
     it 'finds builds by a given list of ids' do
-      @params = { :ids => [build.id] }
-      service.run.should == [build]
+      @params = { :ids => [push.id] }
+      service.run.should == [push]
     end
 
-    describe 'with pull requests' do
-      it 'finds pull requests for event_type=pull_request' do
-        request = Factory(:request, :event_type => 'pull_request')
-        pull_request = Factory(:build, :repository => repo, :state => :finished, :number => 2, :request => request)
-        @params = { :event_type => 'pull_request', :repository_id => repo.id }
+    describe 'finds recent builds when event_type' do
+      let!(:pull_request) { Factory(:build, repository: repo, state: :finished, number: 2, request: Factory(:request, :event_type => 'pull_request')) }
+      let!(:api)          { Factory(:build, repository: repo, state: :finished, number: 2, request: Factory(:request, :event_type => 'api')) }
+
+      it 'given as push' do
+        @params = { repository_id: repo.id, event_type: 'push' }
+        service.run.should == [push]
+      end
+
+      it 'given as pull_request' do
+        @params = { repository_id: repo.id, event_type: 'pull_request' }
         service.run.should == [pull_request]
+      end
+
+      it 'given as api' do
+        @params = { repository_id: repo.id, event_type: 'api' }
+        service.run.should == [api]
+      end
+
+      it 'given as [push, api]' do
+        @params = { repository_id: repo.id, event_type: ['push', 'api'] }
+        service.run.sort.should == [push, api]
       end
     end
   end


### PR DESCRIPTION
So that travis-web can request `/builds?event_type=push,api` for the time being.

/cc @drogus, @rkh 