### PR TITLE
job-queue: allow random routing by percentage

### DIFF
--- a/lib/travis/model/job/queue.rb
+++ b/lib/travis/model/job/queue.rb
@@ -81,6 +81,7 @@ class Job
         :sudo => job.config.fetch(:sudo) { !repo_is_default_docker?(job) },
         :dist => job.config[:dist],
         :osx_image => job.config[:osx_image],
+        :percentage => lambda { |percentage| rand(100) < percentage },
       }
     end
 

--- a/spec/travis/model/job/queue_spec.rb
+++ b/spec/travis/model/job/queue_spec.rb
@@ -273,5 +273,15 @@ describe 'Job::Queue' do
       queue = queue('builds.invalid', { foobar_donotmatch: true })
       queue.matches?(stub('job', repository: stub('repository', owner_name: nil, name: nil, owner: nil), config: {})).should be_false
     end
+
+    it 'returns true for percentage: 100' do
+      queue = queue('builds.always', { percentage: 100 })
+      queue.matches?(stub('job', repository: stub('repository', owner_name: nil, name: nil, owner: nil), config: {})).should be_true
+    end
+
+    it 'returns false for percentage: 0' do
+      queue = queue('builds.always', { percentage: 0 })
+      queue.matches?(stub('job', repository: stub('repository', owner_name: nil, name: nil, owner: nil), config: {})).should be_false
+    end
   end
 end


### PR DESCRIPTION
In some cases we want to send a subset of jobs to a new queue, usually for testing out a new infrastructure of some sort. This allows specifying a percentag (in the range [0, 100)), and then the jobs will be distributed with weighted randomness. For example, consider this configuration:

``` YAML
- queue: builds.new-a
  language: a
  percentage: 25
- queue: builds.old-a
  language: a
```

If you have 100 jobs with `language: a`, roughly 25 of them will go to builds.new-a, and the rest will go to builds.old-a.

The way the matching works is by stepping through each config from top to bottom, and applying the first one that matches. With this addition, the `percentage` key will cause it to be possible for the matching to continue to the next config even if the job matched the rest of the config.

/cc @meatballhat 