### PR TITLE
skip build if 'skip travis' is used

### DIFF
--- a/lib/travis/commit_command.rb
+++ b/lib/travis/commit_command.rb
@@ -17,7 +17,7 @@ module Travis
     end
 
     def backwards_skip
-      message =~ /\[skip\s+ci\]/i && true
+      message =~ /\[skip\s+ci|travis\]/i && true
     end
   end
 end

--- a/spec/travis/commit_command_spec.rb
+++ b/spec/travis/commit_command_spec.rb
@@ -31,5 +31,10 @@ describe Travis::CommitCommand do
       message = "foo [skip ci] bar"
       Travis::CommitCommand.new(message).skip?.should eq true
     end
+
+    it 'is invoked by the special case: [skip travis]' do
+      message = "foo [skip travis] bar"
+      Travis::CommitCommand.new(message).skip?.should eq true
+    end
   end
 end


### PR DESCRIPTION
_What_
Allows a user to skip a travis build with [skip travis]

_Why_
This allows me to target a specific CI environment, but still lets travis build other branches.
