### PR TITLE
Improve error handling for event subscriptions looking at missing addons

### DIFF
--- a/lib/travis/event/subscription.rb
+++ b/lib/travis/event/subscription.rb
@@ -33,10 +33,11 @@ module Travis
         self.class.handlers[name.to_sym] || Handler.const_get(name.to_s.camelize, false)
       rescue NameError => e
         Travis.logger.error "Could not find event handler #{name.inspect}, ignoring."
+        nil
       end
 
       def patterns
-        Array(subscriber::EVENTS)
+        subscriber ? Array(subscriber::EVENTS) : []
       end
 
       def notify(event, *args)

--- a/spec/travis/event/subscription_spec.rb
+++ b/spec/travis/event/subscription_spec.rb
@@ -47,15 +47,8 @@ describe Travis::Event::Subscription do
   describe 'a missing event handler' do
     let(:subscription) { Travis::Event::Subscription.new(:missing_handler) }
 
-    # it 'lets Travis::Exception handle the NameError' do
-    #   Travis::Exceptions.expects(:handle).with do |exception|
-    #     exception.should be_kind_of(NameError)
-    #   end
-    #   subscription.subscriber
-    # end
-
     it 'does not raise the exception' do
-     lambda { subscription.subscriber }.should_not raise_error
+      lambda { subscription.notify('build:finished') }.should_not raise_error
     end
   end
 end


### PR DESCRIPTION
After rescueing the exception also need to make sure the caller can deal with the return value.

With a certain event handler present in the config, but missing in the
code, our previous code would catch and log the fact that the constant
is missing. However, the method now also would return `true` (the return
value of `logger.error`), causing the caller to try to find a constant
on the value `true`, which of course would raise a new exception. This
is confusing, and not the behaviour one would expect: broken event
listener configuration should not break the application in general.

This change fixes that, changes the return value for `nil` in the
offending case, and deals with this value appropriately.