### PR TITLE
features: check for owner_active? instead of rollout

### DIFF
--- a/lib/travis/features.rb
+++ b/lib/travis/features.rb
@@ -25,7 +25,7 @@ module Travis
     # By default, this will return false.
     def active?(feature, repository)
       feature_active?(feature) or
-        (rollout.active?(feature, repository.owner) or
+        (owner_active?(feature, repository.owner) or
           repository_active?(feature, repository))
     end
 


### PR DESCRIPTION
This adds support for feature flagging organizations and not just users.