### PR TITLE
Set compare_url when a request is created via api

### DIFF
--- a/lib/travis/requests/services/receive/api.rb
+++ b/lib/travis/requests/services/receive/api.rb
@@ -50,7 +50,7 @@ module Travis
               committer_email: commit_data['commit']['committer']['email'],
               author_name:     commit_data['commit']['author']['name'],
               author_email:    commit_data['commit']['author']['email'],
-              compare_url:     nil
+              compare_url:     commit_data['_links']['self']['href']
             }
           end
 

--- a/spec/travis/requests/services/receive/api_spec.rb
+++ b/spec/travis/requests/services/receive/api_spec.rb
@@ -36,7 +36,7 @@ describe Travis::Requests::Services::Receive::Api do
         committer_email: 'dan@cerebris.com',
         author_name: 'Dan Gebhardt',
         author_email: 'dan@cerebris.com',
-        compare_url: nil
+        compare_url: 'https://api.github.com/repos/svenfuchs/gem-release/commits/b736eea14f5f2094f7c8f7ff902bfaa302c10cbd'
       }
     end
   end


### PR DESCRIPTION
Should implement https://github.com/travis-pro/team-teal/issues/412. 

Needs to be deployed in gatekeeper.