### PR TITLE
Record deployment stats

### DIFF
--- a/lib/travis/travis_yml_stats.rb
+++ b/lib/travis/travis_yml_stats.rb
@@ -120,7 +120,7 @@ module Travis
     end
 
     def set_deployment_provider_count
-      deploy = config["deploy"]
+      deploy = config["deploy"] || return
       # Hash#to_a is not what we want here
       deployments = deploy.is_a?(Hash) ? [deploy] : Array(deploy)
       set [:deployment, :provider], deployments.map { |deployment| deployment["provider"] }

--- a/lib/travis/travis_yml_stats.rb
+++ b/lib/travis/travis_yml_stats.rb
@@ -63,11 +63,7 @@ module Travis
     def set(path, value)
       path = Array(path)
       hsh = keen_payload
-      # drop the last element from path
-      # we are looking at a 2-element array
-      # e.g., [:language_version, 'ruby']
       path[0..-2].each do |key|
-        # []
         hsh[key.to_sym] ||= {}
         hsh = hsh[key.to_sym]
       end

--- a/lib/travis/travis_yml_stats.rb
+++ b/lib/travis/travis_yml_stats.rb
@@ -123,9 +123,7 @@ module Travis
       deploy = config["deploy"]
       # Hash#to_a is not what we want here
       deployments = deploy.is_a?(Hash) ? [deploy] : Array(deploy)
-      deployments.group_by {|deployment| deployment["provider"] }.each do |provider, definition|
-        set [:deployment, :provider, provider], definition.size
-      end
+      set [:deployment, :provider], deployments.map { |deployment| deployment["provider"] }
     end
 
     def config

--- a/spec/travis/travis_yml_stats_spec.rb
+++ b/spec/travis/travis_yml_stats_spec.rb
@@ -4,10 +4,11 @@ require "travis/travis_yml_stats"
 describe Travis::TravisYmlStats do
   let(:publisher) { mock("keen-publisher") }
   subject { described_class.store_stats(request, publisher) }
+  let(:config) { {} }
 
   let(:request) do
     stub({
-      config: {},
+      config: config,
       payload: {
         "repository" => {}
       },

--- a/spec/travis/travis_yml_stats_spec.rb
+++ b/spec/travis/travis_yml_stats_spec.rb
@@ -269,4 +269,31 @@ describe Travis::TravisYmlStats do
       subject
     end
   end
+
+  context "when payload contains a single deployment provider" do
+    let(:config) { { "deploy" => { "provider" => "s3" } } }
+
+    it "reports deployment count correctly" do
+      event_should_contain deployment: { provider: { s3: 1 } }
+      subject
+    end
+  end
+
+  context "when payload contains multiple deployment providers" do
+    let(:config) { { "deploy" => [ { "provider" => "s3" }, { "provider" => "npm" } ] } }
+
+    it "reports deployment count correctly" do
+      event_should_contain deployment: { provider: { s3: 1, npm: 1 } }
+      subject
+    end
+  end
+
+  context "when payload contains multiple deployment providers of the same type" do
+    let(:config) { { "deploy" => [ { "provider" => "s3" }, { "provider" => "s3" } ] } }
+
+    it "reports deployment count correctly" do
+      event_should_contain deployment: { provider: { s3: 2 } }
+      subject
+    end
+  end
 end

--- a/spec/travis/travis_yml_stats_spec.rb
+++ b/spec/travis/travis_yml_stats_spec.rb
@@ -26,6 +26,10 @@ describe Travis::TravisYmlStats do
     publisher.expects(:perform_async).with(has_entries(opts))
   end
 
+  def event_should_not_contain(opts)
+    publisher.expects(:perform_async).with(Not(has_entries(opts)))
+  end
+
   describe ".travis.yml language key" do
     context "when `language: ruby'" do
       before do
@@ -266,6 +270,13 @@ describe Travis::TravisYmlStats do
     it "sets the group_name key to 'dev'" do
       event_should_contain group_name: 'dev'
 
+      subject
+    end
+  end
+
+  context "when payload does not contain deployment provider" do
+    it "reports deployment count correctly" do
+      event_should_not_contain deployment: { provider: [] }
       subject
     end
   end

--- a/spec/travis/travis_yml_stats_spec.rb
+++ b/spec/travis/travis_yml_stats_spec.rb
@@ -274,7 +274,7 @@ describe Travis::TravisYmlStats do
     let(:config) { { "deploy" => { "provider" => "s3" } } }
 
     it "reports deployment count correctly" do
-      event_should_contain deployment: { provider: { s3: 1 } }
+      event_should_contain deployment: { provider: ["s3"] }
       subject
     end
   end
@@ -283,7 +283,7 @@ describe Travis::TravisYmlStats do
     let(:config) { { "deploy" => [ { "provider" => "s3" }, { "provider" => "npm" } ] } }
 
     it "reports deployment count correctly" do
-      event_should_contain deployment: { provider: { s3: 1, npm: 1 } }
+      event_should_contain deployment: { provider: ["s3", "npm"] }
       subject
     end
   end
@@ -292,7 +292,7 @@ describe Travis::TravisYmlStats do
     let(:config) { { "deploy" => [ { "provider" => "s3" }, { "provider" => "s3" } ] } }
 
     it "reports deployment count correctly" do
-      event_should_contain deployment: { provider: { s3: 2 } }
+      event_should_contain deployment: { provider: ["s3", "s3"] }
       subject
     end
   end


### PR DESCRIPTION
Keep track of deployment provider usage in `.travis.yml`.

```yaml
deploy:
  provider: X
  ⋮
```

creates `deployment.provider: ["X"]` in Keen.io.

```yaml
deploy:
  provider: X
  ⋮
  provider: Y
  ⋮
```
creates `deployment.provider: ["X", "Y"]`, and

```yaml
deploy:
  - provider: X
  ⋮
  - provider: X
  ⋮
```

creates `deployment.provider: ["X", "X"]`.