### PR TITLE
Tweak Keen dp

### DIFF
--- a/lib/travis/travis_yml_stats.rb
+++ b/lib/travis/travis_yml_stats.rb
@@ -14,7 +14,8 @@ module Travis
 
       def perform(payload, deployment_payload)
         if defined?(Keen) && ENV["KEEN_PROJECT_ID"]
-          Keen.publish_batch({:requests => [payload], :deployments => deployment_payload})
+          payload = { :requests => [payload] }
+          payload[:deployments] = deployment_payload if deployment_payload.size > 0
         end
       end
     end

--- a/lib/travis/travis_yml_stats.rb
+++ b/lib/travis/travis_yml_stats.rb
@@ -12,13 +12,9 @@ module Travis
 
       sidekiq_options queue: :keen_events
 
-      def perform(payload, collection = :requests)
+      def perform(payload, deployment_payload)
         if defined?(Keen) && ENV["KEEN_PROJECT_ID"]
-          if payload.is_a? Array
-            Keen.publish_batch({collection => payload})
-          else
-            Keen.publish(collection, payload)
-          end
+          Keen.publish_batch({:requests => [payload], :deployments => deployment_payload})
         end
       end
     end
@@ -58,8 +54,7 @@ module Travis
       set_group
       set_deployment_provider_count
 
-      @publisher.perform_async(keen_payload, :requests)
-      @publisher.perform_async(keen_payload_deployment, :deployments)
+      @publisher.perform_async(keen_payload, keen_payload_deployment)
     end
 
     private

--- a/spec/travis/travis_yml_stats_spec.rb
+++ b/spec/travis/travis_yml_stats_spec.rb
@@ -22,18 +22,12 @@ describe Travis::TravisYmlStats do
     })
   end
 
-  def ignore_collection(collection)
-    publisher.expects(:perform_async).with(anything, collection)
-  end
-
   def requests_should_contain(opts)
-    ignore_collection(:deployments)
-    publisher.expects(:perform_async).with(has_entries(opts), :requests)
+    publisher.expects(:perform_async).with(has_entries(opts), anything)
   end
 
   def deployments_should_contain(items)
-    ignore_collection(:requests)
-    publisher.expects(:perform_async).with(all_of(items.each {|i| includes(i)}), :deployments)
+    publisher.expects(:perform_async).with(anything, all_of(items.each {|i| includes(i)}))
   end
 
   describe ".travis.yml language key" do

--- a/spec/travis/travis_yml_stats_spec.rb
+++ b/spec/travis/travis_yml_stats_spec.rb
@@ -22,12 +22,18 @@ describe Travis::TravisYmlStats do
     })
   end
 
-  def event_should_contain(opts)
-    publisher.expects(:perform_async).with(has_entries(opts))
+  def ignore_collection(collection)
+    publisher.expects(:perform_async).with(anything, collection)
   end
 
-  def event_should_not_contain(opts)
-    publisher.expects(:perform_async).with(Not(has_entries(opts)))
+  def requests_should_contain(opts)
+    ignore_collection(:deployments)
+    publisher.expects(:perform_async).with(has_entries(opts), :requests)
+  end
+
+  def deployments_should_contain(items)
+    ignore_collection(:requests)
+    publisher.expects(:perform_async).with(all_of(items.each {|i| includes(i)}), :deployments)
   end
 
   describe ".travis.yml language key" do
@@ -37,7 +43,7 @@ describe Travis::TravisYmlStats do
       end
 
       it "sets the language key to 'ruby'" do
-        event_should_contain language: "ruby"
+        requests_should_contain language: "ruby"
 
         subject
       end
@@ -45,7 +51,7 @@ describe Travis::TravisYmlStats do
 
     context "when not specified" do
       it "sets the language key to nil" do
-        event_should_contain language: "default"
+        requests_should_contain language: "default"
 
         subject
       end
@@ -57,7 +63,7 @@ describe Travis::TravisYmlStats do
       end
 
       it "sets the language key to 'invalid'" do
-        event_should_contain language: "invalid"
+        requests_should_contain language: "invalid"
 
         subject
       end
@@ -69,7 +75,7 @@ describe Travis::TravisYmlStats do
       end
 
       it "retains the space" do
-        event_should_contain language: "objective c"
+        requests_should_contain language: "objective c"
 
         subject
       end
@@ -83,7 +89,7 @@ describe Travis::TravisYmlStats do
       end
 
       it "sets the github_language key to 'Ruby'" do
-        event_should_contain github_language: "Ruby"
+        requests_should_contain github_language: "Ruby"
 
         subject
       end
@@ -95,7 +101,7 @@ describe Travis::TravisYmlStats do
       end
 
       it "sets the github_language key to 'F#'" do
-        event_should_contain github_language: "F#"
+        requests_should_contain github_language: "F#"
 
         subject
       end
@@ -107,7 +113,7 @@ describe Travis::TravisYmlStats do
       end
 
       it "sets the github_language key to nil" do
-        event_should_contain github_language: nil
+        requests_should_contain github_language: nil
 
         subject
       end
@@ -121,7 +127,7 @@ describe Travis::TravisYmlStats do
       end
 
       it "sets the language_version.ruby key to ['2.1.2']" do
-        event_should_contain language_version: { ruby: ["2.1.2"] }
+        requests_should_contain language_version: { ruby: ["2.1.2"] }
 
         subject
       end
@@ -133,7 +139,7 @@ describe Travis::TravisYmlStats do
       end
 
       it "sets the language_version.ruby key to ['2.0.0', '2.1.2']" do
-        event_should_contain language_version: { ruby: %w[2.0.0 2.1.2] }
+        requests_should_contain language_version: { ruby: %w[2.0.0 2.1.2] }
 
         subject
       end
@@ -145,7 +151,7 @@ describe Travis::TravisYmlStats do
       end
 
       it "sets the language_version.ruby key to ['2.0', '2.1.2']" do
-        event_should_contain language_version: { ruby: %w[2.0 2.1.2] }
+        requests_should_contain language_version: { ruby: %w[2.0 2.1.2] }
 
         subject
       end
@@ -159,7 +165,7 @@ describe Travis::TravisYmlStats do
       end
 
       it "sets the uses_sudo key to true" do
-        event_should_contain uses_sudo: true
+        requests_should_contain uses_sudo: true
 
         subject
       end
@@ -167,7 +173,7 @@ describe Travis::TravisYmlStats do
 
     context "sudo is not used in any commands" do
       it "sets the uses_sudo key to false" do
-        event_should_contain uses_sudo: false
+        requests_should_contain uses_sudo: false
 
         subject
       end
@@ -181,7 +187,7 @@ describe Travis::TravisYmlStats do
       end
 
       it "sets the uses_apt_get key to true" do
-        event_should_contain uses_apt_get: true
+        requests_should_contain uses_apt_get: true
 
         subject
       end
@@ -189,7 +195,7 @@ describe Travis::TravisYmlStats do
 
     context "apt-get is not used in any commands" do
       it "sets the uses_apt_get key to false" do
-        event_should_contain uses_apt_get: false
+        requests_should_contain uses_apt_get: false
 
         subject
       end
@@ -202,7 +208,7 @@ describe Travis::TravisYmlStats do
     end
 
     it "sets the event_type to 'push'" do
-      event_should_contain event_type: "push"
+      requests_should_contain event_type: "push"
 
       subject
     end
@@ -214,7 +220,7 @@ describe Travis::TravisYmlStats do
     end
 
     it "sets the event_type to 'pull_request'" do
-      event_should_contain event_type: "pull_request"
+      requests_should_contain event_type: "pull_request"
 
       subject
     end
@@ -222,21 +228,21 @@ describe Travis::TravisYmlStats do
 
   describe "a build with two jobs" do
     it "sets the matrix_size to 2" do
-      event_should_contain matrix_size: 2
+      requests_should_contain matrix_size: 2
 
       subject
     end
   end
 
   it "owner_type and owner_id are set" do
-    event_should_contain owner_id: 234, owner_type: "User", owner: ["User", 234]
+    requests_should_contain owner_id: 234, owner_type: "User", owner: ["User", 234]
 
     subject
   end
 
   describe "a request without 'dist' key" do
     it "sets the dist_name key to 'default'" do
-      event_should_contain dist_name: 'default'
+      requests_should_contain dist_name: 'default'
 
       subject
     end
@@ -248,7 +254,7 @@ describe Travis::TravisYmlStats do
     end
 
     it "sets the dist_name key to 'trusty'" do
-      event_should_contain dist_name: 'trusty'
+      requests_should_contain dist_name: 'trusty'
 
       subject
     end
@@ -256,7 +262,7 @@ describe Travis::TravisYmlStats do
 
   describe "a request without 'group' key" do
     it "sets the group_name key to 'default'" do
-      event_should_contain group_name: 'default'
+      requests_should_contain group_name: 'default'
 
       subject
     end
@@ -268,15 +274,8 @@ describe Travis::TravisYmlStats do
     end
 
     it "sets the group_name key to 'dev'" do
-      event_should_contain group_name: 'dev'
+      requests_should_contain group_name: 'dev'
 
-      subject
-    end
-  end
-
-  context "when payload does not contain deployment provider" do
-    it "reports deployment count correctly" do
-      event_should_not_contain deployment: { provider: [] }
       subject
     end
   end
@@ -285,7 +284,7 @@ describe Travis::TravisYmlStats do
     let(:config) { { "deploy" => { "provider" => "s3" } } }
 
     it "reports deployment count correctly" do
-      event_should_contain deployment: { provider: ["s3"] }
+      deployments_should_contain( [{:provider => 's3', :repository_id => 123}] )
       subject
     end
   end
@@ -294,7 +293,7 @@ describe Travis::TravisYmlStats do
     let(:config) { { "deploy" => [ { "provider" => "s3" }, { "provider" => "npm" } ] } }
 
     it "reports deployment count correctly" do
-      event_should_contain deployment: { provider: ["s3", "npm"] }
+      deployments_should_contain( [{:provider => 's3', :repository_id => 123}, {:provider => 'npm', :repository_id => 123}] )
       subject
     end
   end
@@ -303,7 +302,7 @@ describe Travis::TravisYmlStats do
     let(:config) { { "deploy" => [ { "provider" => "s3" }, { "provider" => "s3" } ] } }
 
     it "reports deployment count correctly" do
-      event_should_contain deployment: { provider: ["s3", "s3"] }
+      deployments_should_contain( [{:provider => 's3', :repository_id => 123}] )
       subject
     end
   end


### PR DESCRIPTION
Create a new Keen event collection, "deployments" to track deployment data. Compare to "requests", there are far fewer of these (right now, anyway).

This allows easier query on Keen; e.g.,

```javascript
Keen.ready(function(){
  
  var query = new Keen.Query("count_unique", {
    eventCollection: "deployments",
    groupBy: "provider",
    targetProperty: "repository_id",
    timeframe: "this_7_days",
    timezone: "UTC"
  });
  
  client.draw(query, document.getElementById("my_chart"), {
    // Custom configuration here
  });
  
});
```

![travis_ci___org__staging_-_explorer_-_keen_io](https://cloud.githubusercontent.com/assets/25666/9827606/dba55e02-58b1-11e5-91d8-b883007b630d.png)
