### PR TITLE
add category column to broadcasts table

### DIFF
--- a/db/migrate/20150923131400_broadcasts_add_category.rb
+++ b/db/migrate/20150923131400_broadcasts_add_category.rb
@@ -1,0 +1,5 @@
+class BroadcastsAddCategory < ActiveRecord::Migration
+  def change
+    add_column :broadcasts, :category, :string
+  end
+end


### PR DESCRIPTION
This adds a "category" column to the broadcasts table which will enable us to define the category of broadcast (eg, "announcement" or "warning").

To define the broadcast admin (where broadcasts are created) will be updated.