### PR TITLE
Clean up Keen data collection issues

### DIFF
--- a/lib/travis/travis_yml_stats.rb
+++ b/lib/travis/travis_yml_stats.rb
@@ -12,7 +12,7 @@ module Travis
 
       sidekiq_options queue: :keen_events
 
-      def perform(payload, deployment_payload, notification_payload)
+      def perform(payload, deployment_payload = nil, notification_payload = nil)
         if defined?(Keen) && ENV["KEEN_PROJECT_ID"]
           payload = { :requests => [payload] }
           payload[:deployments] = deployment_payload if deployment_payload.size > 0

--- a/lib/travis/travis_yml_stats.rb
+++ b/lib/travis/travis_yml_stats.rb
@@ -128,7 +128,7 @@ module Travis
       # Hash#to_a is not what we want here
       deployments = deploy.is_a?(Hash) ? [deploy] : Array(deploy)
       deployments.map {|d| d["provider"] }.uniq.each do |provider|
-        keen_payload_deployment << { provider: provider, repository_id: request.repository_id }
+        keen_payload_deployment << { provider: provider.downcase, repository_id: request.repository_id }
       end
     rescue
       nil
@@ -137,7 +137,7 @@ module Travis
     def set_notification
       notifications = config["notifications"] || return
       notifications.keys.each do |notifier|
-        keen_payload_notification << { notifier: notifier, repository_id: request.repository_id }
+        keen_payload_notification << { notifier: notifier.downcase, repository_id: request.repository_id }
       end
     rescue
       nil

--- a/lib/travis/travis_yml_stats.rb
+++ b/lib/travis/travis_yml_stats.rb
@@ -130,6 +130,8 @@ module Travis
       deployments.map {|d| d["provider"] }.uniq.each do |provider|
         keen_payload_deployment << { provider: provider, repository_id: request.repository_id }
       end
+    rescue
+      nil
     end
 
     def set_notification
@@ -137,6 +139,8 @@ module Travis
       notifications.keys.each do |notifier|
         keen_payload_notification << { notifier: notifier, repository_id: request.repository_id }
       end
+    rescue
+      nil
     end
 
     def config


### PR DESCRIPTION
1. When user passes ill-formed data to `notifications` or `deploy`, we could see an exception when sending data to Keen. Instead of giving up entirely, we just ignore the data, so that we can still send requests data.
1. Normalize the notifiers and deployment provider names, so that, for example, `S3` and `s3` are considered the same.
1. Prevent `ArgumentError` when method signature does not match the payload. We had some issues when we introduced it.