### PR TITLE
add migration for creating starred_repositories table

### DIFF
--- a/db/migrate/20151112153500_create_starred_repositories.rb
+++ b/db/migrate/20151112153500_create_starred_repositories.rb
@@ -3,8 +3,6 @@ class CreateStarredRepositories < ActiveRecord::Migration
     create_table :starred_repositories do |t|
       t.integer   :repo_id
       t.integer   :user_id
-      t.datetime  :created_at
-      t.datetime  :updated_at
       t.timestamps
     end
 

--- a/db/migrate/20151112153500_create_starred_repositories.rb
+++ b/db/migrate/20151112153500_create_starred_repositories.rb
@@ -1,0 +1,18 @@
+class CreateStarredRepositories < ActiveRecord::Migration
+  def self.up
+    create_table :starred_repositories do |t|
+      t.integer   :repo_id
+      t.integer   :user_id
+      t.datetime  :created_at
+      t.datetime  :updated_at
+      t.timestamps
+    end
+
+    add_index :starred_repositories, :user_id
+  end
+
+
+  def self.down
+    drop_table :starred_repositories
+  end
+end


### PR DESCRIPTION
Adds a new `starred_repositories` table to the DB. This will be used to store information about which repos users have 'starred' to appear at the top of their dashboard.

This migration has been run on our `travis-staging` database without issues.