### PR TITLE
Cd starred repo index

### DIFF
--- a/db/migrate/201511113111400_starred_repositories_add_index_user_id_and_repo_id.rb
+++ b/db/migrate/201511113111400_starred_repositories_add_index_user_id_and_repo_id.rb
@@ -1,0 +1,11 @@
+class StarredRepositoriesAddIndexUserIdAndRepoId < ActiveRecord::Migration
+  self.disable_ddl_transaction!
+
+  def up
+    execute "CREATE INDEX index_starred_repositories_on_user_id_and_repo_id ON starred_repositories (user_id, repo_id)"
+  end
+
+  def down
+    execute "DELETE INDEX index_starred_repositories_on_user_id_and_repo_id"
+  end
+end

--- a/db/migrate/201511113111400_starred_repositories_add_index_user_id_and_repo_id.rb
+++ b/db/migrate/201511113111400_starred_repositories_add_index_user_id_and_repo_id.rb
@@ -2,7 +2,7 @@ class StarredRepositoriesAddIndexUserIdAndRepoId < ActiveRecord::Migration
   self.disable_ddl_transaction!
 
   def up
-    execute "CREATE INDEX index_starred_repositories_on_user_id_and_repo_id ON starred_repositories (user_id, repo_id)"
+    execute "CREATE UNIQUE INDEX index_starred_repositories_on_user_id_and_repo_id ON starred_repositories (user_id, repo_id)"
   end
 
   def down

--- a/db/migrate/201511113111400_starred_repositories_add_index_user_id_and_repo_id.rb
+++ b/db/migrate/201511113111400_starred_repositories_add_index_user_id_and_repo_id.rb
@@ -6,6 +6,6 @@ class StarredRepositoriesAddIndexUserIdAndRepoId < ActiveRecord::Migration
   end
 
   def down
-    execute "DELETE INDEX index_starred_repositories_on_user_id_and_repo_id"
+    execute "DROP INDEX index_starred_repositories_on_user_id_and_repo_id"
   end
 end


### PR DESCRIPTION
To create a unique index on the starred_repositories table for user_is and repo_id.

This will ensure any concurrency possible errors are mitigated.

This migration has been run on the staging db successfully.