### PR TITLE
Handle empty matrix.include

### DIFF
--- a/lib/travis/model/build/config/dist.rb
+++ b/lib/travis/model/build/config/dist.rb
@@ -29,7 +29,9 @@ class Build
           matrix = c.fetch(:matrix, {})
           return c unless config_hashy?(matrix)
 
-          matrix.fetch(:include, []).each do |inc|
+          included = matrix.fetch(:include, []) || []
+
+          included.each do |inc|
             next unless config_hashy?(inc)
             next if inc.key?(:dist) || inc.key?('dist')
             inc.merge!(dist: dist_for_config(inc))

--- a/spec/travis/model/build/matrix_spec.rb
+++ b/spec/travis/model/build/matrix_spec.rb
@@ -294,6 +294,14 @@ describe Build, 'matrix' do
     yml
     }
 
+    let(:matrix_with_empty_include) {
+      YAML.load <<-yml
+      language: ruby
+      matrix:
+        include:
+    yml
+    }
+
     let(:multiple_tests_config_with_allow_failures) {
       YAML.load <<-yml
       language: objective-c
@@ -581,6 +589,16 @@ describe Build, 'matrix' do
           { os: 'linux', language: 'ruby', group: 'stable', dist: 'precise', rvm: '2.1.0', env: 'BAR=true' },
           { os: 'linux', language: 'ruby', group: 'stable', dist: 'precise', rvm: '1.9.3', env: 'BAZ=true' }
         ]
+      end
+
+      it 'includes "empty" matrix config when matrix.include is null' do
+        build = Factory(:build, config: matrix_with_empty_include)
+
+        matrix_inclusion = {
+          include: nil
+        }
+
+        build.matrix.map(&:config).should == []
       end
     end
 


### PR DESCRIPTION
Do not throw `NoMethodError` when matrix.include is empty