### PR TITLE
Optimize query that is done for clearing log parts

### DIFF
--- a/lib/travis/model/log.rb
+++ b/lib/travis/model/log.rb
@@ -41,6 +41,7 @@ class Log < Travis::Model
     update_column(:archived_at, nil)
     update_column(:archive_verified, nil)
     Log::Part.where(log_id: id).delete_all
+    parts.reload
   end
 
   def archived?

--- a/lib/travis/model/log.rb
+++ b/lib/travis/model/log.rb
@@ -40,7 +40,7 @@ class Log < Travis::Model
     update_column(:aggregated_at, nil) # TODO why in the world does update_attributes not set aggregated_at to nil?
     update_column(:archived_at, nil)
     update_column(:archive_verified, nil)
-    parts.delete_all
+    Log::Part.where(log_id: id).delete_all
   end
 
   def archived?


### PR DESCRIPTION
`parts.delete_all` will first fetch every log part and then do a delete query for each log part that is retrieved, while `Log::Part.where().delete_all` will run a single query to delete every log part. `delete_all` does mean that the callbacks are bypassed, but that was the same as the previous behaviour.