### PR TITLE
Reject build request if compare URL is too long

### DIFF
--- a/lib/travis/model/request/approval.rb
+++ b/lib/travis/model/request/approval.rb
@@ -19,6 +19,7 @@ class Request
         !repository.private? &&
         (!excluded_repository? || included_repository?) &&
         !skipped? &&
+        !compare_url_too_long? &&
         enabled_in_settings?
     end
 
@@ -44,6 +45,10 @@ class Request
 
     def allow_builds_without_travis_yml?
       !repository.builds_only_with_travis_yml?
+    end
+
+    def compare_url_too_long?
+      commit.compare_url.length > 255
     end
 
     def approved?
@@ -75,6 +80,8 @@ class Request
         'private repository'
       elsif !request.creates_jobs?
         'matrix created no jobs'
+      elsif compare_url_too_long?
+        'compare URL too long; branch/tag names may be too long'
       end
     end
 

--- a/spec/travis/model/request/approval_spec.rb
+++ b/spec/travis/model/request/approval_spec.rb
@@ -90,6 +90,11 @@ describe Request::Approval do
       approval.stubs(:enabled_in_settings?).returns(false)
       approval.should_not be_accepted
     end
+
+    it 'does not accept a request when compare URL is too long' do
+      request.commit.stubs(:compare_url).returns('a'*256)
+      approval.should_not be_accepted
+    end
   end
 
   describe 'approved?' do
@@ -145,6 +150,12 @@ describe Request::Approval do
       request.commit.stubs(:branch).returns('feature')
       request.stubs(:config).returns('branches' => { 'only' => 'master' })
       approval.message.should == 'branch not included or excluded'
+    end
+
+    it 'returns "compare URL too long; branch/tag names may be too long" if the compare URL is too long' do
+      request.stubs(:config).returns({key: 'value'})
+      request.commit.stubs(:compare_url).returns('a'*256)
+      approval.message.should == 'compare URL too long; branch/tag names may be too long'
     end
   end
 

--- a/spec/travis/model/request/states_spec.rb
+++ b/spec/travis/model/request/states_spec.rb
@@ -5,7 +5,7 @@ describe Request::States do
 
   let(:owner)      { User.new(:login => 'joshk') }
   let(:repository) { Repository.new(:name => 'travis-ci', :owner => owner, :owner_name => 'travis-ci') }
-  let(:commit)     { Commit.new(:repository => repository, :commit => '12345', :branch => 'master', :message => 'message', :committed_at => Time.now) }
+  let(:commit)     { Commit.new(:repository => repository, :commit => '12345', :branch => 'master', :message => 'message', :committed_at => Time.now, :compare_url => 'https://github.com/svenfuchs/minimal/compare/master...develop') }
   let(:request)    { Request.new(:repository => repository, :commit => commit) }
 
   let(:approval)   { Request::Approval.any_instance }


### PR DESCRIPTION
The type for compare URLs in our database is VARCHAR(255).
Rather than accepting the request and throwing an exception
later (without a chance to let users know), we reject the
build request and advise to shorten branch/tag name.