### PR TITLE
Reduce complexity of updating branch.last_build_id

### DIFF
--- a/lib/travis/model/branch.rb
+++ b/lib/travis/model/branch.rb
@@ -3,22 +3,4 @@ require 'travis/model'
 class Branch < Travis::Model
   belongs_to :repository
   belongs_to :last_build, class_name: 'Build'
-
-  def self.fetch(repository, name, force_update = false)
-    name        ||= 'master'
-    repository_id = Integer === repository ? repository : repository.id
-    branch        = where(repository_id: repository_id, name: name).first_or_initialize
-
-    if branch.new_record? or force_update
-      branch.last_build = repository.last_build_on(branch.name)
-      Travis.logger.info 'Updating last_build to %s on branch %s, repo %s' % [branch.last_build.try(:id), branch.try(:name), repository.respond_to?(:slug) ? repository.slug : repository.id]
-      branch.save!
-    end
-
-    branch
-  end
-
-  def self.update_build(repository, name)
-    fetch(repository, name, true)
-  end
 end

--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -47,7 +47,7 @@ class Build < Travis::Model
   require 'travis/model/build/states'
   require 'travis/model/env_helpers'
 
-  include Matrix, States, SimpleStates, UpdateBranch
+  include Matrix, States, SimpleStates
 
   belongs_to :commit
   belongs_to :request
@@ -154,11 +154,14 @@ class Build < Travis::Model
     expand_matrix
   end
 
+  after_create do
+    UpdateBranch.new(self).update_last_build
+  end
+
   after_save do
     unless cached_matrix_ids
       update_column(:cached_matrix_ids, to_postgres_array(matrix_ids))
     end
-    update_branch
   end
 
   # AR 3.2 does not handle pg arrays and the plugins supporting them

--- a/lib/travis/model/build/update_branch.rb
+++ b/lib/travis/model/build/update_branch.rb
@@ -1,7 +1,37 @@
 class Build
-  module UpdateBranch
-    def update_branch
-      Branch.update_build(repository, branch)
+  class UpdateBranch < Struct.new(:build)
+    MSGS = {
+      update: 'Setting last_build_id to %s on branch %s, repo %s',
+      kaputt: 'Inconsistent branch.last_build_id=%s on branch: %s (repo: %s). Should be: %s.'
+    }
+
+    def update_last_build
+      logger.info MSGS[:update] % [build.id, branch_name, repository.slug]
+      branch.update_attributes!(last_build_id: build.id)
+      validate_branch_last_build_id # TODO double check and remove after a few days
     end
+
+    private
+
+      def validate_branch_last_build_id
+        return if branch.reload.last_build_id == build.id
+        logger.warn MSGS[:kaputt] % [branch.last_build_id, branch_name, repository.slug, build.id]
+      end
+
+      def branch
+        Branch.where(repository_id: repository.id, name: branch_name).first_or_create
+      end
+
+      def branch_name
+        build.branch || 'master'
+      end
+
+      def repository
+        build.repository
+      end
+
+      def logger
+        Travis.logger
+      end
   end
 end

--- a/spec/travis/model/build/update_branch_spec.rb
+++ b/spec/travis/model/build/update_branch_spec.rb
@@ -1,51 +1,25 @@
 require 'spec_helper'
 
-describe Build, 'update_branch' do
+describe Build::UpdateBranch do
   include Support::ActiveRecord
 
-  let(:build) { Factory(:build, state: :started, duration: 30, branch: 'master') }
+  let(:build)  { Factory.build(:build, state: :started, duration: 30, branch: 'master') }
+  let(:branch) { Branch.where(repository_id: build.repository_id, name: build.branch).first }
 
-  describe 'on build:started' do
-    it 'creates branch if branch is missing' do
-      Branch.fetch(build.repository, 'master').destroy
-      Branch.where(repository_id: build.repository_id, name: build.branch).should_not be_any
+  subject { described_class.new(build) }
 
-      build.update_branch
-
-      branch = Branch.where(repository_id: build.repository_id, name: build.branch).first
-      branch.should_not be_nil
-      branch.last_build.should be == build
+  describe 'on build creation' do
+    describe 'creates branch if missing' do
+      before { build.save }
+      it { branch.should_not be_nil }
+      it { branch.last_build_id.should be == build.id }
     end
 
-    it 'updates branch if branch is exists' do
-      Branch.fetch(build.repository, 'master')
-
-      build.update_branch
-
-      branch = Branch.fetch(build.repository, 'master')
-      branch.last_build.should be == build
-    end
-  end
-
-  describe 'on build:finished' do
-    it 'creates branch if branch is missing' do
-      Branch.fetch(build.repository, 'master').destroy
-      Branch.where(repository_id: build.repository_id, name: build.branch).should_not be_any
-
-      build.update_branch
-
-      branch = Branch.where(repository_id: build.repository_id, name: build.branch).first
-      branch.should_not be_nil
-      branch.last_build.should be == build
-    end
-
-    it 'updates branch if branch is exists' do
-      Branch.fetch(build.repository, 'master')
-
-      build.update_branch
-
-      branch = Branch.fetch(build.repository, 'master')
-      branch.last_build.should be == build
+    describe 'updates an existing branch' do
+      before { Branch.create!(repository_id: build.repository_id, name: 'master') }
+      before { build.save }
+      it { branch.should_not be_nil }
+      it { branch.last_build_id.should be == build.id }
     end
   end
 end


### PR DESCRIPTION
At the moment a build's branch's `last_build_id` is not always consistent. I'm stumped at figuring out why that would happen, but it does.

This pull request should reduce some unnecessary complexity from this part of the logic, and adds an additional validation/logging step (can be removed once we've figured this out).

This stuff happens in Gatekeeper. We create a new build, and we regard this build as the "last build" on the build's branch.

Changes:

* Don't call updating the branch's `last_build_id` in the build's `after_save` hook. Use the `after_create` hook instead, because that's the timing we care about.
* Directly set the currently created `build.id` to `branch.last_build_id` instead of going through `repo.last_build_on(branch_name)`. This also spares a potentially expensive query.
* After the update, reload the branch model and verify `last_build_id` has the expected value `build.id`

Opinions?