### PR TITLE
Add R language key

### DIFF
--- a/lib/travis/model/build/config.rb
+++ b/lib/travis/model/build/config.rb
@@ -39,6 +39,7 @@ class Build
       :ruby,
       :rust,
       :rvm,
+      :r,
       :scala,
       :smalltalk,
       :visualbasic,
@@ -74,6 +75,7 @@ class Build
       'python'      => [:python],
       'ruby'        => [:rvm, :gemfile, :jdk, :ruby],
       'rust'        => [:rust],
+      'r'           => [:r],
       'scala'       => [:scala, :jdk],
       'smalltalk'   => [:smalltalk],
       'visualbasic' => [:visualbasic, :mono]


### PR DESCRIPTION
Add a R language key for matrix build support after https://github.com/travis-ci/travis-build/pull/621 is merged.