### PR TITLE
add statement_timeout to database config

### DIFF
--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -14,7 +14,7 @@ module Travis
             auth:          { target_origin: nil },
             assets:        { host: HOSTS[Travis.env.to_sym] },
             amqp:          { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 },
-            database:      { adapter: 'postgresql', database: "travis_#{Travis.env}", encoding: 'unicode', min_messages: 'warning' },
+            database:      { adapter: 'postgresql', database: "travis_#{Travis.env}", encoding: 'unicode', min_messages: 'warning', variables: { statement_timeout: 10_000 } },
             s3:            { access_key_id: '', secret_access_key: '' },
             pusher:        { app_id: 'app-id', key: 'key', secret: 'secret' },
             sidekiq:       { namespace: 'sidekiq', pool_size: 1 },

--- a/spec/travis/config_spec.rb
+++ b/spec/travis/config_spec.rb
@@ -69,7 +69,8 @@ describe Travis::Config do
         :adapter => 'postgresql',
         :database => 'travis_test',
         :encoding => 'unicode',
-        :min_messages => 'warning'
+        :min_messages => 'warning',
+        :variables => { :statement_timeout => 10000 }
       }
     end
   end


### PR DESCRIPTION
This reinstates a timeout that was removed when db config got removed from the keychain.

Normally this would be set by `travis-config` but since there is a conflict between the version of Hashr `travis-config` needs, and the (earlier) version of Hashr `travis-core` requires, for now we need to set this variable here in `travis-core`.

When `travis-core` is eventually removed from `travis-api` we will be able to have api use `travis-config` to set this config variable.

I've checked this on api-staging to make sure the config variable is being loaded:
`{:adapter=>"postgresql",
 :database=>"xxxx",
 :encoding=>"unicode",
 :min_messages=>"warning",
 :variables=>{:statement_timeout=>10000, :application_name=>"api-staging-run.8545"},
 :username=>"xxxx",
 :password=>"xxxx",
 :host=>"ec2-107-20-225-109.compute-1.amazonaws.com",
 :port=>"5902",
 :pool=>1}`

The spec has been updated to include the new variable.