### PR TITLE
remove Jruby from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: ruby
 
 sudo: false
 
-env:
-  - JRUBY_OPTS="--dev -Xcext.enabled=false -Xcompile.invokedynamic=false -J-Xmx1g"
-
 services:
   - redis
 
@@ -21,26 +18,16 @@ cache:
 sudo: false
 
 rvm:
-  - jruby-1.7.16
-  - jruby-head
-  - jruby-9.0.0.0
   - "2.0"
   - "2.1"
 
-jdk: oraclejdk7
-
 matrix:
   fast_finish: true
-  allow_failures:
-    - rvm: jruby-head
-    - rvm: jruby-9.0.0.0
 
 before_install:
-  - if [ $TRAVIS_RUBY_VERSION = 'jruby-9.0.0.0' ]; then rvm get head; rvm use --install jruby-9.0.0.0; ruby --version; fi
   - gem install bundler -v 1.9.0
 
 install:
-  # JRuby fails to resolve dependencies on newer bundler
   - bundle _1.9.0_ install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
 
 before_script:


### PR DESCRIPTION
Since any app using `core` no longer uses Jruby, the requirement to run tests against Jruby has been removed from the travis.yml file.

I've checked that the following apps do not use jRuby:

admin-staging/production
gatekeeper-staging/prod
api-staging/production

Tests are passing locally and more than 25 mins quicker on travis-ci.

This addresses issue: travis-pro/team-teal#759