### PR TITLE
Create shared parent class for logs classes

### DIFF
--- a/lib/travis/model.rb
+++ b/lib/travis/model.rb
@@ -7,6 +7,7 @@ require 'core_ext/active_record/base'
 
 module Travis
   class Model < ActiveRecord::Base
+    require 'travis/model/logs_model'
     require 'travis/model/account'
     require 'travis/model/annotation'
     require 'travis/model/annotation_provider'

--- a/lib/travis/model/log.rb
+++ b/lib/travis/model/log.rb
@@ -2,7 +2,7 @@ require 'metriks'
 require 'active_support/core_ext/string/filters'
 require 'travis/model'
 
-class Log < Travis::Model
+class Log < Travis::LogsModel
   require 'travis/model/log/part'
 
   AGGREGATE_PARTS_SELECT_SQL = <<-sql.squish

--- a/lib/travis/model/log/part.rb
+++ b/lib/travis/model/log/part.rb
@@ -1,4 +1,4 @@
-class Log::Part < Travis::Model
+class Log::Part < Travis::LogsModel
   self.table_name = 'log_parts'
 
   validates :log_id, presence: true, numericality: { greater_than: 0 }

--- a/lib/travis/model/logs_model.rb
+++ b/lib/travis/model/logs_model.rb
@@ -1,0 +1,3 @@
+class Travis::LogsModel < ActiveRecord::Base
+  self.abstract_class = true
+end


### PR DESCRIPTION
Database connections in ActiveRecord are bound to a class, so in order
to use only one connection for both classes we need to have a shared
parent class.