### PR TITLE
Add attribute and validation for rate_limit

### DIFF
--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -86,8 +86,13 @@ class Repository::Settings < Travis::Settings
   attribute :ssh_key, SshKey
   attribute :timeout_hard_limit
   attribute :timeout_log_silence
+  attribute :rate_limit, Integer
 
   validates :maximum_number_of_builds, numericality: true
+  validates :rate_limit, numericality: true
+
+  validate :restricts_rate_limit
+
 
   validates_with TimeoutsValidator
 
@@ -110,6 +115,13 @@ class Repository::Settings < Travis::Settings
     value = super
     value == 0 ? nil : value
   end
+
+  def restricts_rate_limit?
+    if rate_limit > 200
+      errors.add (:rate_limit, "can't be more than 200")
+    end
+  end
+
 
   def repository_id
     additional_attributes[:repository_id]

--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -87,6 +87,7 @@ class Repository::Settings < Travis::Settings
   attribute :timeout_hard_limit
   attribute :timeout_log_silence
   attribute :rate_limit, Integer
+  attribute :errors
 
   validates :maximum_number_of_builds, numericality: true
   validates :rate_limit, numericality: true

--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -118,7 +118,7 @@ class Repository::Settings < Travis::Settings
 
   def restricts_rate_limit?
     if rate_limit > 200
-      errors.add (:rate_limit, "can't be more than 200")
+      errors.add(:rate_limit, "can't be more than 200")
     end
   end
 

--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -87,7 +87,6 @@ class Repository::Settings < Travis::Settings
   attribute :timeout_hard_limit
   attribute :timeout_log_silence
   attribute :rate_limit, Integer
-  attribute :errors
 
   validates :maximum_number_of_builds, numericality: true
   validates :rate_limit, numericality: true

--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -116,6 +116,10 @@ class Repository::Settings < Travis::Settings
     value == 0 ? nil : value
   end
 
+  def rate_limit
+    super || 0
+  end
+
   def rate_limit_restriction
     if rate_limit > 200
       errors.add(:rate_limit, "can't be more than 200")

--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -91,7 +91,7 @@ class Repository::Settings < Travis::Settings
   validates :maximum_number_of_builds, numericality: true
   validates :rate_limit, numericality: true
 
-  validate :restricts_rate_limit
+  validate :rate_limit_restriction
 
 
   validates_with TimeoutsValidator
@@ -116,7 +116,7 @@ class Repository::Settings < Travis::Settings
     value == 0 ? nil : value
   end
 
-  def restricts_rate_limit?
+  def rate_limit_restriction
     if rate_limit > 200
       errors.add(:rate_limit, "can't be more than 200")
     end

--- a/spec/travis/model/repository/settings_spec.rb
+++ b/spec/travis/model/repository/settings_spec.rb
@@ -46,6 +46,18 @@ describe Repository::Settings do
     settings.should be_valid
   end
 
+  describe '#rate_limit' do
+    it 'saves new rate_limit if rate is under 200' do
+      settings = Repository::Settings.new(rate_limit: 2)
+      settings.should be_valid
+    end
+
+    it 'does not save new rate_limit if rate is over 200' do
+      settings = Repository::Settings.new(rate_limit: 201)
+      settings.should_not be_valid
+    end
+  end
+
   describe 'timeouts' do
     MAX = {
       off: { hard_limit: 50, log_silence: 10 },


### PR DESCRIPTION
Still needs a spec

This updates the repository to add a `rate_limit` attribute in the repository settings.
There is also validation to prevent the rate limit from being higher than 200.