### PR TITLE
Update naming of api_builds_rate_limit

### DIFF
--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -42,7 +42,8 @@ module Travis
             states_cache:  { memcached_servers: 'localhost:11211' },
             sentry:        { },
             services:      { find_requests: { max_limit: 100, default_limit: 25 } },
-            settings:      { timeouts: { defaults: { hard_limit: 50, log_silence: 10 }, maximums: { hard_limit: 180, log_silence: 60 } } },
+            settings:      { timeouts: { defaults: { hard_limit: 50, log_silence: 10 }, maximums: { hard_limit: 180, log_silence: 60 } },
+                             api_builds: { defaults: { rate_limit: 10 }, maximums: { rate_limit: 200 } } },
             endpoints:     { }
 
     default :_access => [:key]

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -43,7 +43,7 @@ module Travis
             sentry:        { },
             services:      { find_requests: { max_limit: 100, default_limit: 25 } },
             settings:      { timeouts: { defaults: { hard_limit: 50, log_silence: 10 }, maximums: { hard_limit: 180, log_silence: 60 } },
-                             api_builds: { defaults: { rate_limit: 10 }, maximums: { rate_limit: 200 } } },
+                             rate_limit: { defaults: { api_builds: 10 }, maximums: { api_builds: 200 } } },
             endpoints:     { }
 
     default :_access => [:key]

--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -86,12 +86,12 @@ class Repository::Settings < Travis::Settings
   attribute :ssh_key, SshKey
   attribute :timeout_hard_limit
   attribute :timeout_log_silence
-  attribute :rate_limit, Integer
+  attribute :api_builds_rate_limit, Integer
 
   validates :maximum_number_of_builds, numericality: true
-  validates :rate_limit, numericality: true
+  validates :api_builds_rate_limit, numericality: true
 
-  validate :rate_limit_restriction
+  validate :api_builds_rate_limit_restriction
 
 
   validates_with TimeoutsValidator
@@ -116,13 +116,13 @@ class Repository::Settings < Travis::Settings
     value == 0 ? nil : value
   end
 
-  def rate_limit
+  def api_builds_rate_limit
     super || 0
   end
 
-  def rate_limit_restriction
-    if rate_limit > 200
-      errors.add(:rate_limit, "can't be more than 200")
+  def api_builds_rate_limit_restriction
+    if api_builds_rate_limit > 200
+      errors.add(:api_builds_rate_limit, "can't be more than 200")
     end
   end
 

--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -117,11 +117,11 @@ class Repository::Settings < Travis::Settings
   end
 
   def api_builds_rate_limit
-    super || Travis.config.settings.api_builds.defaults.rate_limit
+    super || Travis.config.settings.rate_limit.defaults.api_builds
   end
 
   def api_builds_rate_limit_restriction
-    if api_builds_rate_limit > Travis.config.settings.api_builds.maximums.rate_limit
+    if api_builds_rate_limit > Travis.config.settings.rate_limit.maximums.api_builds
       errors.add(:api_builds_rate_limit, "can't be more than 200")
     end
   end

--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -117,11 +117,11 @@ class Repository::Settings < Travis::Settings
   end
 
   def api_builds_rate_limit
-    super || 0
+    super || Travis.config.settings.api_builds.defaults.rate_limit
   end
 
   def api_builds_rate_limit_restriction
-    if api_builds_rate_limit > 200
+    if api_builds_rate_limit > Travis.config.settings.api_builds.maximums.rate_limit
       errors.add(:api_builds_rate_limit, "can't be more than 200")
     end
   end

--- a/spec/travis/model/repository/settings_spec.rb
+++ b/spec/travis/model/repository/settings_spec.rb
@@ -56,6 +56,12 @@ describe Repository::Settings do
       settings = Repository::Settings.new(api_builds_rate_limit: 201)
       settings.should_not be_valid
     end
+
+    it 'sets default api_builds_rate_limit if value is nil' do
+      settings = Repository::Settings.new(api_builds_rate_limit: nil)
+      settings.api_builds_rate_limit.should eq(10)
+      settings.should be_valid
+    end
   end
 
   describe 'timeouts' do

--- a/spec/travis/model/repository/settings_spec.rb
+++ b/spec/travis/model/repository/settings_spec.rb
@@ -46,14 +46,14 @@ describe Repository::Settings do
     settings.should be_valid
   end
 
-  describe '#rate_limit' do
-    it 'saves new rate_limit if rate is under 200' do
-      settings = Repository::Settings.new(rate_limit: 2)
+  describe '#api_builds_rate_limit' do
+    it 'saves new api_builds_rate_limit if rate is under 200' do
+      settings = Repository::Settings.new(api_builds_rate_limit: 2)
       settings.should be_valid
     end
 
-    it 'does not save new rate_limit if rate is over 200' do
-      settings = Repository::Settings.new(rate_limit: 201)
+    it 'does not save new api_builds_rate_limit if rate is over 200' do
+      settings = Repository::Settings.new(api_builds_rate_limit: 201)
       settings.should_not be_valid
     end
   end


### PR DESCRIPTION
This updates the name of the rate limit for api builds, and configures default and maximum values through config.

The current default rate limit in effect is 10 requests per 30 seconds, so we have added a default value of 10.

The maximum limit suggested by @rkh was 200.