### PR TITLE
Return nil if no value is set for api_builds_rate_limit

### DIFF
--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -4,6 +4,7 @@ require 'travis/settings'
 require 'travis/overwritable_method_definitions'
 require 'travis/settings/encrypted_value'
 require 'openssl'
+require 'pry'
 
 class Repository::Settings < Travis::Settings
   class EnvVar < Travis::Settings::Model
@@ -89,10 +90,8 @@ class Repository::Settings < Travis::Settings
   attribute :api_builds_rate_limit, Integer
 
   validates :maximum_number_of_builds, numericality: true
-  validates :api_builds_rate_limit, numericality: true
 
   validate :api_builds_rate_limit_restriction
-
 
   validates_with TimeoutsValidator
 
@@ -117,11 +116,11 @@ class Repository::Settings < Travis::Settings
   end
 
   def api_builds_rate_limit
-    super || Travis.config.settings.rate_limit.defaults.api_builds
+    super || nil
   end
 
   def api_builds_rate_limit_restriction
-    if api_builds_rate_limit > Travis.config.settings.rate_limit.maximums.api_builds
+    if api_builds_rate_limit.to_i > Travis.config.settings.rate_limit.maximums.api_builds
       errors.add(:api_builds_rate_limit, "can't be more than 200")
     end
   end

--- a/spec/travis/model/repository/settings_spec.rb
+++ b/spec/travis/model/repository/settings_spec.rb
@@ -57,10 +57,9 @@ describe Repository::Settings do
       settings.should_not be_valid
     end
 
-    it 'sets default api_builds_rate_limit if value is nil' do
-      settings = Repository::Settings.new(api_builds_rate_limit: nil)
-      settings.api_builds_rate_limit.should eq(10)
-      settings.should be_valid
+    it 'returns nil if no api_builds_rate_limit is set on settings' do
+      settings = Repository::Settings.new()
+      settings.api_builds_rate_limit.should eq(nil)
     end
   end
 


### PR DESCRIPTION
Returning nil if nothing is set, in order to use config values on the API 