### PR TITLE
Coerce config into a Hash before passing it to S3 service

### DIFF
--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -78,7 +78,7 @@ module Travis
             entries = [entries] unless entries.is_a? Array
             entries.map do |entry|
               next unless config = entry[:s3]
-              service = ::S3::Service.new(config.slice(:secret_access_key, :access_key_id))
+              service = ::S3::Service.new(config.to_h.slice(:secret_access_key, :access_key_id))
               service.buckets.find(config.fetch(:bucket_name))
             end.compact
           end


### PR DESCRIPTION
Hashr does not appear to implement `#slice`, and we are getting
`{}` when we call it.