### PR TITLE
 Downcase retrieved language on config before creating the build

### DIFF
--- a/lib/travis/model/request/states.rb
+++ b/lib/travis/model/request/states.rb
@@ -53,6 +53,9 @@ class Request
     end
 
     def add_build
+      if config && config[:language]
+        config[:language] = config[:language].to_s.downcase
+      end
       builds.create!(:repository => repository, :commit => commit, :config => config, :owner => owner)
     end
 

--- a/spec/travis/model/request/states_spec.rb
+++ b/spec/travis/model/request/states_spec.rb
@@ -250,5 +250,19 @@ describe Request::States do
       Travis::Event.expects(:dispatch).with { |e, *| e.should == "build:created" }.never
       request.add_build_and_notify
     end
+
+    it "should downcase the language on the configuration" do
+      request.config = { language: "Java" }
+      request.save
+      request.add_build_and_notify.should be_a(Build)
+      Build.last.config[:language].should eq "java"
+    end
+
+    it "should return the default language on the configuration" do
+      request.config = { env: 'FOO=foo' }
+      request.save
+      request.add_build_and_notify.should be_a(Build)
+      Build.last.config[:language].should eq "ruby"
+    end
   end
 end


### PR DESCRIPTION
The language attribute  in `.travis.yml` should be downcased before creating the build
https://github.com/travis-pro/team-teal/issues/780