### PR TITLE
Add GCS cache listing ability

### DIFF
--- a/lib/travis/services/delete_caches.rb
+++ b/lib/travis/services/delete_caches.rb
@@ -7,7 +7,7 @@ module Travis
 
       def run
         caches = run_service(:find_caches, params)
-        caches.each { |c| c.s3_object.destroy }
+        caches.each { |c| c.destroy }
         caches
       end
     end

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -37,11 +37,12 @@ module Travis
       end
 
       class GcsWrapper
-        attr_reader :storage, :bucket_name, :cache_object
+        attr_reader :storage, :bucket_name, :repository, :cache_object
 
-        def initialize(storage, bucket_name, cache_object)
-          @storage = storage
-          @bucket_name = bucket_name
+        def initialize(storage, bucket_name, repository, cache_object)
+          @storage      = storage
+          @bucket_name  = bucket_name
+          @repository   = repository
           @cache_object = cache_object
         end
 
@@ -58,7 +59,7 @@ module Travis
         end
 
         def branch
-          s3_object.name[%r{^\d+/(.*)/[^/]+$}, 1]
+          cache_object.name[%r{^\d+/(.*)/[^/]+$}, 1]
         end
 
         def destroy
@@ -131,7 +132,7 @@ module Travis
               Travis.logger.info("storage=#{storage}")
               storage.list_objects(bucket_name, prefix: prefix).items.map do |object|
                 Travis.logger.info("item=#{object}")
-                c << GcsWrapper.new(storage, bucket_name, object)
+                c << GcsWrapper.new(storage, bucket_name, repo, object)
               end
             end
           end

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -112,6 +112,7 @@ module Travis
             if config = entry[:s3]
               svc = ::S3::Service.new(config.to_h.slice(:secret_access_key, :access_key_id))
               bucket = svc.buckets.find(config.fetch(:bucket_name))
+              next unless bucket
               c += bucket.objects(options).map { |object| S3Wrapper.new(repo, object) }
             elsif config = entry[:gcs]
               storage = Google::Apis::StorageV1::StorageService.new

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -15,6 +15,10 @@ module Travis
           @s3_object  = s3_object
         end
 
+        def source
+          'S3'
+        end
+
         def last_modified
           s3_object.last_modified
         end
@@ -53,6 +57,10 @@ module Travis
           @bucket_name  = bucket_name
           @repository   = repository
           @cache_object = cache_object
+        end
+
+        def source
+          'GCS'
         end
 
         def last_modified

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -95,10 +95,7 @@ module Travis
       private
 
         def setup?
-          return true if entries.any? do |entry|
-            (s3_config  = entry[:s3])  && s3_config[:access_key_id] && s3_config[:secret_access_key] && s3_config[:bucket_name] or
-            (gcs_config = entry[:gcs]) && gcs_config[:json_key] && gcs_config[:bucket_name]
-          end
+          return true if entries.any? { |entry| valid?(entry) }
 
           logger.warn "[services:find-caches] cache settings incomplete"
           false
@@ -170,6 +167,17 @@ module Travis
           collection
         end
 
+        def valid?(entry)
+          valid_s3?(entry) or valid_gcs?(entry)
+        end
+
+        def valid_s3?(entry)
+          (s3_config  = entry[:s3]) && s3_config[:access_key_id] && s3_config[:secret_access_key] && s3_config[:bucket_name]
+        end
+
+        def valid_gcs?(entry)
+          (gcs_config = entry[:gcs]) && gcs_config[:json_key] && gcs_config[:bucket_name]
+        end
     end
   end
 end

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -78,7 +78,9 @@ module Travis
         end
 
         def content
-          storage.get_object(bucket_name, cache_object.name, download_dest: $stdout)
+          io = StringIO.new
+          storage.get_object(bucket_name, cache_object.name, download_dest: io)
+          io.read
         end
       end
 

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -115,9 +115,9 @@ module Travis
               next unless bucket
               c += bucket.objects(options).map { |object| S3Wrapper.new(repo, object) }
             elsif config = entry[:gcs]
-              storage = Google::Apis::StorageV1::StorageService.new
+              storage = ::Google::Apis::StorageV1::StorageService.new
               json_key_io = StringIO.new(config.to_h[:json_key])
-              storage.authorization = Google::Auth::ServiceAccountCredentials.make_creds(
+              storage.authorization = ::Google::Auth::ServiceAccountCredentials.make_creds(
                 json_key_io: json_key_io,
                 scope: [
                   'https://www.googleapis.com/auth/devstorage.read_write'

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -135,7 +135,9 @@ module Travis
               )
               bucket_name = config[:bucket_name]
 
-              storage.list_objects(bucket_name, prefix: prefix).items.map do |object|
+              next unless items = storage.list_objects(bucket_name, prefix: prefix).items
+
+              items.map do |object|
                 c << GcsWrapper.new(storage, bucket_name, repo, object)
               end
             end

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -6,7 +6,7 @@ module Travis
     class FindCaches < Base
       register :find_caches
 
-      class Wrapper
+      class S3Wrapper
         attr_reader :repository, :s3_object
 
         def initialize(repository, s3_object)
@@ -28,6 +28,40 @@ module Travis
 
         def branch
           s3_object.key[%r{^\d+/(.*)/[^/]+$}, 1]
+        end
+
+        def destroy
+          s3_object.destroy
+        end
+      end
+
+      class GcsWrapper
+        attr_reader :storage, :bucket_name, :cache_object
+
+        def initialize(storage, bucket_name, cache_object)
+          @storage = storage
+          @bucket_name = bucket_name
+          @cache_object = cache_object
+        end
+
+        def last_modified
+          cache_object.updated
+        end
+
+        def size
+          Integer(cache_object.size)
+        end
+
+        def slug
+          File.basename(cache_object.name, '.tbz')
+        end
+
+        def branch
+          s3_object.name[%r{^\d+/(.*)/[^/]+$}, 1]
+        end
+
+        def destroy
+          storage.delete_object(bucket_name, cache_object.name)
         end
       end
 
@@ -78,7 +112,20 @@ module Travis
             if config = entry[:s3]
               svc = ::S3::Service.new(config.to_h.slice(:secret_access_key, :access_key_id))
               bucket = svc.buckets.find(config.fetch(:bucket_name))
-              c += bucket.objects(options).map { |object| Wrapper.new(repo, object) }
+              c += bucket.objects(options).map { |object| S3Wrapper.new(repo, object) }
+            elsif config = entry[:gcs]
+              storage = Google::Apis::StorageV1::StorageService.new
+              json_key_io = StringIO.new(config.to_h[:json_key])
+              storage.authorization = Google::Auth::ServiceAccountCredentials.make_creds(
+                json_key_io: json_key_io,
+                scope: [
+                  'https://www.googleapis.com/auth/devstorage.read_write'
+                ]
+              )
+              bucket_name = config[:bucket_name]
+              storage.list_objects(bucket_name, prefix: prefix).items.map do |object|
+                GcsWrapper.new(storage, bucket_name, object)
+              end
             end
           end
 

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -80,6 +80,7 @@ module Travis
         def content
           io = StringIO.new
           storage.get_object(bucket_name, cache_object.name, download_dest: io)
+          io.rewind
           io.read
         end
       end

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -121,19 +121,21 @@ module Travis
             if config = entry[:s3]
               svc = ::S3::Service.new(config.to_h.slice(:secret_access_key, :access_key_id))
               bucket = svc.buckets.find(config.fetch(:bucket_name))
+
               next unless bucket
 
               c += bucket.objects(options).map { |object| S3Wrapper.new(repo, object) }
             elsif config = entry[:gcs]
-              storage = ::Google::Apis::StorageV1::StorageService.new
+              storage     = ::Google::Apis::StorageV1::StorageService.new
               json_key_io = StringIO.new(config.to_h[:json_key])
+              bucket_name = config[:bucket_name]
+
               storage.authorization = ::Google::Auth::ServiceAccountCredentials.make_creds(
                 json_key_io: json_key_io,
                 scope: [
                   'https://www.googleapis.com/auth/devstorage.read_write'
                 ]
               )
-              bucket_name = config[:bucket_name]
 
               next unless items = storage.list_objects(bucket_name, prefix: prefix).items
 

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -35,6 +35,14 @@ module Travis
           Travis.logger.info "action=delete backend=s3 s3_object=#{s3_object.key}"
           s3_object.destroy
         end
+
+        def temporary_url
+          s3_object.temporary_url
+        end
+
+        def content
+          s3_object.content
+        end
       end
 
       class GcsWrapper
@@ -67,6 +75,10 @@ module Travis
           Travis.logger.info "action=delete backend=gcs bucket_name=#{bucket_name} cache_name=#{cache_object.name}"
           storage.delete_object(bucket_name, cache_object.name)
         rescue Google::Apis::ClientError
+        end
+
+        def content
+          storage.get_object(bucket_name, cache_object.name, download_dest: $stdout)
         end
       end
 

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -33,8 +33,7 @@ module Travis
 
       def run
         return [] unless setup? and permission?
-        caches = objects(prefix: prefix).map { |object| Wrapper.new(repo, object) }
-        caches.select! { |o| o.slug.include?(params[:match]) } if params[:match]
+        caches(prefix: prefix).select! { |o| o.slug.include?(params[:match]) } if params[:match]
         caches
       end
 
@@ -66,6 +65,10 @@ module Travis
           prefix = "#{repo.github_id}/"
           prefix << branch << '/' if branch
           prefix
+        end
+
+        def caches(options)
+          objects(prefix: prefix).map { |object| Wrapper.new(repo, object) }
         end
 
         def objects(options)

--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -1,5 +1,6 @@
 require 's3'
 require 'travis/services/base'
+require 'google/apis/storage_v1'
 
 module Travis
   module Services

--- a/spec/support.rb
+++ b/spec/support.rb
@@ -4,6 +4,7 @@ require 'support/payloads'
 module Support
   autoload :ActiveRecord,   'support/active_record'
   autoload :Formats,        'support/formats'
+  autoload :GCS,            'support/gcs'
   autoload :Log,            'support/log'
   autoload :Mocks,          'support/mocks'
   autoload :Notifications,  'support/notifications'

--- a/spec/support/gcs.rb
+++ b/spec/support/gcs.rb
@@ -1,0 +1,42 @@
+require 'google/apis/storage_v1'
+
+module Support
+  module GCS
+    class FakeObject
+      attr_accessor :key, :size
+      def initialize(key, options = {})
+        @key  = key
+        @size = options[:size] || "0"
+      end
+    end
+
+    class FakeService
+      def authorization=(auth)
+        true
+      end
+
+      def list_objects(*args)
+        FakeObjects.new
+      end
+    end
+
+    class FakeObjects
+      def items
+        []
+      end
+    end
+
+    class FakeAuthorization
+    end
+
+    extend ActiveSupport::Concern
+
+    included do
+      before :each do
+        ::Google::Apis::StorageV1::StorageService.stubs(:new).returns(gcs_storage)
+        ::Google::Auth::ServiceAccountCredentials.stubs(:make_creds).returns(FakeAuthorization.new)
+      end
+      let(:gcs_storage) { FakeService.new }
+    end
+  end
+end

--- a/spec/travis/services/find_caches_spec.rb
+++ b/spec/travis/services/find_caches_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Travis::Services::FindCaches do
-  include Support::ActiveRecord, Support::S3
+  include Support::ActiveRecord, Support::S3, Support::GCS
 
   let(:user) { User.first || Factory(:user) }
   let(:service) { described_class.new(user, params) }
@@ -66,6 +66,11 @@ describe Travis::Services::FindCaches do
         let(:cache_options) {[{ s3: { bucket_name: '', access_key_id: '', secret_access_key: '' } }, { s3: { bucket_name: '', access_key_id: '', secret_access_key: '' } }]}
         its(:size) { should be == 4 }
       end
+    end
+
+    context 'with GCS configuration' do
+      let(:cache_options) { { gcs: { bucket_name: '', json_key: '' } } }
+      its(:size) { should be == 0 }
     end
   end
 end

--- a/spec/travis/services/find_caches_spec.rb
+++ b/spec/travis/services/find_caches_spec.rb
@@ -56,11 +56,11 @@ describe Travis::Services::FindCaches do
         its(:size) { should be == 0 }
       end
 
-      describe 'without s3 credentials' do
-        let(:cache_options) {{ }}
-        before { service.logger.expects(:warn).with("[services:find-caches] S3 credentials missing") }
-        it { should be == [] }
-      end
+      # describe 'without s3 credentials' do
+      #   let(:cache_options) {{ }}
+      #   before { service.logger.expects(:warn).with("[services:find-caches] S3 credentials missing") }
+      #   it { should be == [] }
+      # end
 
       describe 'with multiple buckets' do
         let(:cache_options) {[{ s3: { bucket_name: '' } }, { s3: { bucket_name: '' } }]}

--- a/spec/travis/services/find_caches_spec.rb
+++ b/spec/travis/services/find_caches_spec.rb
@@ -6,7 +6,7 @@ describe Travis::Services::FindCaches do
   let(:user) { User.first || Factory(:user) }
   let(:service) { described_class.new(user, params) }
   let(:repo) { Factory(:repository, :owner_name => 'travis-ci', :name => 'travis-core') }
-  let(:cache_options) {{ s3: { bucket_name: '' } }}
+  let(:cache_options) {{ s3: { bucket_name: '' , access_key_id: '', secret_access_key: ''} }}
   let(:has_access) { true }
   let(:result) { service.run }
   subject { result }
@@ -56,14 +56,14 @@ describe Travis::Services::FindCaches do
         its(:size) { should be == 0 }
       end
 
-      # describe 'without s3 credentials' do
-      #   let(:cache_options) {{ }}
-      #   before { service.logger.expects(:warn).with("[services:find-caches] S3 credentials missing") }
-      #   it { should be == [] }
-      # end
+      describe 'without s3 credentials' do
+        let(:cache_options) {{ }}
+        before { service.logger.expects(:warn).with("[services:find-caches] cache settings incomplete") }
+        it { should be == [] }
+      end
 
       describe 'with multiple buckets' do
-        let(:cache_options) {[{ s3: { bucket_name: '' } }, { s3: { bucket_name: '' } }]}
+        let(:cache_options) {[{ s3: { bucket_name: '', access_key_id: '', secret_access_key: '' } }, { s3: { bucket_name: '', access_key_id: '', secret_access_key: '' } }]}
         its(:size) { should be == 4 }
       end
     end

--- a/travis-core.gemspec
+++ b/travis-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = '[none]'
 
   s.add_dependency 'rake'
-  s.add_dependency 'thor',              '~> 0.14.6'
+  s.add_dependency 'thor'
   s.add_dependency 'activerecord',      '~> 3.2.19'
   s.add_dependency 'actionmailer',      '~> 3.2.19'
   s.add_dependency 'railties',          '~> 3.2.19'
@@ -45,4 +45,5 @@ Gem::Specification.new do |s|
   s.add_dependency 's3',                '~> 0.3'
   s.add_dependency 'gh'
   s.add_dependency 'multi_json'
+  s.add_dependency 'google-api-client', '~> 0.9.4'
 end


### PR DESCRIPTION
This PR adds the ability to access caches backed by Google Cloud Storage using [google-api-client](https://rubygems.org/gems/google-api-client).

The configuration would look like:

```yaml
  cache_options:
  - s3:
      access_key_id: AK*************Q
      secret_access_key: U*******************O
      bucket_name: foo-bar-coffee-buzz-buzz
  - gcs:
      project_id: foo-bar-1234567
      json_key: | # we need a string here to create a StringIO object
        {
          "type": "service_account",
          "project_id": "foo-bar-1234567",
          "private_key_id": "1234567890abcdef",
          "private_key": "-----BEGIN PRIVATE KEY-----\nPRIVATE_KEEEEEY\n-----END PRIVATE KEY-----\n",
          "client_email": "foo@example.com",
          "client_id": "387143871333",
          "auth_uri": "https://accounts.google.com/o/oauth2/auth",
          "token_uri": "https://accounts.google.com/o/oauth2/token",
          "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
          "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/foobarbuzzbuzz%40foo-bar-coffee-buzz-buzz.iam.gserviceaccount.com"
        }
      bucket_name: foo-bar-coffee-buzz-buzz
```

This PR also adds `#source` method to the cache wrapper class, so that the consumers of the `find_caches` service can inspect where the cache resides. This might be important for display purposes.