### PR TITLE
Downcase language directly on the Language class

### DIFF
--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -155,7 +155,6 @@ class Build < Travis::Model
     self.pull_request_title = request.pull_request_title
     self.pull_request_number = request.pull_request_number
     self.branch = commit.branch
-    self.config[:language] = self.config[:language].to_s.downcase
     expand_matrix
   end
 

--- a/lib/travis/model/build/config/language.rb
+++ b/lib/travis/model/build/config/language.rb
@@ -4,7 +4,8 @@ class Build
   class Config
     class Language < Struct.new(:config, :options)
       def run
-        config[:language] = Array.wrap(config[:language]).first || DEFAULT_LANG
+        config[:language] = Array.wrap(config[:language]).first.to_s.downcase
+        config[:language] = DEFAULT_LANG if config[:language].empty?
         config.select { |key, _| include_key?(key) }
       end
 
@@ -24,4 +25,3 @@ class Build
     end
   end
 end
-

--- a/spec/travis/model/build_spec.rb
+++ b/spec/travis/model/build_spec.rb
@@ -34,11 +34,6 @@ describe Build do
     build.should_not be_cancelable
   end
 
-  it 'downcases the language on config' do
-    build = Factory.create(:build, config: { language: "PYTHON" })
-    build.config[:language].should == "python"
-  end
-
   describe '#secure_env_enabled?' do
     it 'returns true if we\'re not dealing with pull request' do
       build = Factory.build(:build)
@@ -232,6 +227,16 @@ describe Build do
       it 'deep_symbolizes keys on write' do
         build = Factory(:build, config: { 'foo' => { 'bar' => 'bar' } })
         build.read_attribute(:config)[:foo].should == { bar: 'bar' }
+      end
+
+      it 'downcases the language on config' do
+        build = Factory.create(:build, config: { language: "PYTHON" })
+        Build.last.config[:language].should == "python"
+      end
+
+      it 'sets ruby as default language' do
+        build = Factory.create(:build, config: { 'foo' => { 'bar' => 'bar' } })
+        Build.last.config[:language].should == "ruby"
       end
     end
 


### PR DESCRIPTION
This modifies the way we set  `config[:language]` on the Language class, in order to downcase it or use the DEFAULT_LANGUAGE. 
This way, the language modification is propagated to the database, accessible everywhere, and mainly the `language` attribute on the .travis.yml file won't be case sensitive anymore.