### PR TITLE
Ensure allow_failures config is an array

### DIFF
--- a/lib/travis/model/build/config/matrix.rb
+++ b/lib/travis/model/build/config/matrix.rb
@@ -19,7 +19,7 @@ class Build
       end
 
       def allow_failure_configs
-        (settings[:allow_failures] || []).select do |config|
+        Array(settings[:allow_failures] || []).select do |config|
           # TODO check with @drogus how/when this might happen
           config = config.to_hash.symbolize_keys if config.respond_to?(:to_hash)
         end

--- a/spec/travis/model/build/matrix_spec.rb
+++ b/spec/travis/model/build/matrix_spec.rb
@@ -336,6 +336,20 @@ describe Build, 'matrix' do
     yml
     }
 
+    let(:scalar_allow_failures) {
+      YAML.load <<-yml
+      env:
+        global:
+          - "GLOBAL=global NEXT_GLOBAL=next"
+        matrix:
+          - "FOO=bar"
+          - "FOO=baz"
+      matrix:
+        allow_failures:
+          "FOO=bar"
+    yml
+    }
+
     let(:matrix_with_unwanted_expansion_ruby) {
       YAML.load <<-yml
       language: ruby
@@ -454,6 +468,16 @@ describe Build, 'matrix' do
         end
 
         it 'excludes matrices correctly' do
+          @build.matrix.map(&:allow_failure).should == [false, false]
+        end
+      end
+
+      context 'when matrix specifies scalar allow_failures' do
+        before :each do
+          @build = Factory(:build, config: scalar_allow_failures)
+        end
+
+        it 'ignores allow_failures silently' do
           @build.matrix.map(&:allow_failure).should == [false, false]
         end
       end


### PR DESCRIPTION
And ignore `allow_failures` silently.

Another reasonable behavior would be to try to match the scalar value with a job in the matrix and exclude that. This approach will require some extra work while processing config to ensure that the data structures match.