### PR TITLE
Ensure config[:addons] is reasonable when deploy is present

### DIFF
--- a/lib/travis/model/job.rb
+++ b/lib/travis/model/job.rb
@@ -178,7 +178,12 @@ class Job < Travis::Model
 
       if config[:deploy]
         config[:addons] ||= {}
-        config[:addons][:deploy] = config.delete(:deploy)
+        if config[:addons].is_a? Hash
+          config[:addons][:deploy] = config.delete(:deploy)
+        else
+          config.delete(:addons)
+          config[:addons] = { deploy: config.delete(:deploy) }
+        end
       end
 
       config

--- a/lib/travis/model/job.rb
+++ b/lib/travis/model/job.rb
@@ -177,7 +177,6 @@ class Job < Travis::Model
       config = config ? config.deep_symbolize_keys : {}
 
       if config[:deploy]
-        config[:addons] ||= {}
         if config[:addons].is_a? Hash
           config[:addons][:deploy] = config.delete(:deploy)
         else

--- a/spec/travis/model/job_spec.rb
+++ b/spec/travis/model/job_spec.rb
@@ -156,6 +156,7 @@ describe Job do
         rvm: '1.8.7',
       }
     end
+
     context 'when job has secure env disabled' do
       let :job do
         job = Job.new(repository: Factory(:repository))
@@ -434,6 +435,22 @@ describe Job do
           }
         }
       end
+
+      it 'removes addons config if it is an array and deploy is present' do
+        config = { rvm: '1.8.7',
+                   addons: ["foo"],
+                   deploy: { foo: 'bar'}
+                 }
+        job.config = config
+
+        job.decrypted_config.should == {
+          rvm: '1.8.7',
+          addons: {
+            deploy: { foo: 'bar' }
+          }
+        }
+      end
+
     end
   end
 


### PR DESCRIPTION
We should drop non-Hash addons config when a top-level
deploy key is present.

When the top-level deploy key is present, while normalizing,
an addons value that is not a Hash will be sent `#[]`,
which is raises `NoMethodError`.