### PR TITLE
Prefer 'missing config' error message to 'github pages branch'

### DIFF
--- a/lib/travis/model/request/approval.rb
+++ b/lib/travis/model/request/approval.rb
@@ -68,10 +68,10 @@ class Request
         'skipped through commit message'
       elsif disabled_in_settings?
         request.pull_request? ? 'pull requests disabled' : 'pushes disabled'
-      elsif github_pages?
-        'github pages branch'
       elsif request.config.blank?
         'missing config'
+      elsif github_pages?
+        'github pages branch'
       elsif !branch_approved? || !branch_accepted?
         'branch not included or excluded'
       elsif !config_accepted?

--- a/spec/travis/model/request/approval_spec.rb
+++ b/spec/travis/model/request/approval_spec.rb
@@ -138,6 +138,7 @@ describe Request::Approval do
 
     it 'returns "github pages branch" if the branch is a github pages branch' do
       request.commit.stubs(:branch).returns('gh-pages')
+      request.stubs(:config).returns('branches' => { 'only' => 'master' })
       approval.message.should == 'github pages branch'
     end
 


### PR DESCRIPTION
Fixes https://github.com/travis-ci/travis-ci/issues/5933

If `.travis.yml` contains a YAML syntax error on the `gh-pages`
branch, we display the error message "github pages branch" even if
`gh-pages` is (textually) whitelisted in that file.

We should display "missing config" instead.