### PR TITLE
Tweak 'config missig' error message

### DIFF
--- a/lib/travis/model/request/approval.rb
+++ b/lib/travis/model/request/approval.rb
@@ -69,7 +69,7 @@ class Request
       elsif disabled_in_settings?
         request.pull_request? ? 'pull requests disabled' : 'pushes disabled'
       elsif request.config.blank?
-        'missing config'
+        'config is missing or contains YAML syntax error'
       elsif github_pages?
         'github pages branch'
       elsif !branch_approved? || !branch_accepted?

--- a/lib/travis/model/request/states.rb
+++ b/lib/travis/model/request/states.rb
@@ -34,7 +34,7 @@ class Request
 
     def finish
       if config.blank?
-        Travis.logger.warn("[request:finish] Request not creating a build: config is blank, config=#{config.inspect} commit=#{commit.try(:commit).inspect}")
+        Travis.logger.warn("[request:finish] Request not creating a build: config is blank or contains YAML syntax error, config=#{config.inspect} commit=#{commit.try(:commit).inspect}")
       elsif !approved?
         Travis.logger.warn("[request:finish] Request not creating a build: not approved commit=#{commit.try(:commit).inspect} message=#{approval.message.inspect}")
       elsif parse_error?

--- a/spec/travis/model/request/approval_spec.rb
+++ b/spec/travis/model/request/approval_spec.rb
@@ -142,9 +142,9 @@ describe Request::Approval do
       approval.message.should == 'github pages branch'
     end
 
-    it 'returns "missing config" if the config is not present' do
+    it 'returns "config is missing or contains YAML syntax error" if the config is not present' do
       request.stubs(:config).returns(nil)
-      approval.message.should == 'missing config'
+      approval.message.should == 'config is missing or contains YAML syntax error'
     end
 
     it 'returns "branch not included or excluded" if the branch was not approved' do


### PR DESCRIPTION
Config can be blank if exception is thrown while processing the file
due to YAML syntax error