### PR TITLE
Improve query for listing builds `after-number` (i.e. builds `older_than`)

### DIFF
--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -130,7 +130,7 @@ class Build < Travis::Model
     end
 
     def older_than(build = nil)
-      scope = order(number: :desc).paged({}) # TODO in which case we'd call older_than without an argument?
+      scope = order('number::integer DESC').paged({}) # TODO in which case we'd call older_than without an argument?
       scope = scope.where('number::integer < ?', (build.is_a?(Build) ? build.number : build).to_i) if build
       scope
     end

--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -130,7 +130,7 @@ class Build < Travis::Model
     end
 
     def older_than(build = nil)
-      scope = descending.paged({}) # TODO in which case we'd call older_than without an argument?
+      scope = order(number: :desc).paged({}) # TODO in which case we'd call older_than without an argument?
       scope = scope.where('number::integer < ?', (build.is_a?(Build) ? build.number : build).to_i) if build
       scope
     end


### PR DESCRIPTION
After some DB digging it was apparent that postgres was handling the following API request without using any indexes, resulting in incredibly long request times and causing time outs.

https://api.travis-ci.org/repos/twbs/bootstrap/builds?after_number=1500

Adding a three-column index plus adjusting the query to order by `build.number` meant postgres would then utilise this index and run the query in a fraction of the time.

Tests are passing on Travis-ci and a branch of api has been updated and pushed to staging, where all is working correctly.

This addresses this issue: https://secure.helpscout.net/conversation/194688663/28221/?folderId=30784