### PR TITLE
Enable memcached in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 services:
   - redis
+  - memcached
 
 addons:
   postgresql: 9.3

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :test do
   gem 'webmock',          '~> 1.8.0'
   gem 'guard'
   gem 'guard-rspec'
+  gem 'listen',           '< 3.1.0'
   gem 'rb-fsevent'
   gem 'simplecov', require: false
 end

--- a/spec/travis/states_cache_spec.rb
+++ b/spec/travis/states_cache_spec.rb
@@ -79,7 +79,7 @@ module Travis
         data = { id: 10, state: 'failed' }.stringify_keys
         subject.write(1, 'master', data)
 
-        subject.fetch(1, 'master')['state'].should == 'passed'
+        subject.fetch(1, 'master')['state'].should == 'failed'
 
         data = { id: 10, state: 'passed' }.stringify_keys
         subject.write(1, 'master', data)


### PR DESCRIPTION
This PR adds memcached service to the builds, so that we do not skip tests related to it.

This also alters an existing spec, which does not appear to have been tested until now.