### PR TITLE
Show correct error messages in Request::Approval

### DIFF
--- a/lib/travis/model/request/approval.rb
+++ b/lib/travis/model/request/approval.rb
@@ -68,8 +68,6 @@ class Request
         'skipped through commit message'
       elsif disabled_in_settings?
         request.pull_request? ? 'pull requests disabled' : 'pushes disabled'
-      elsif request.config.blank?
-        'config is missing or contains YAML syntax error'
       elsif github_pages?
         'github pages branch'
       elsif !branch_approved? || !branch_accepted?
@@ -82,6 +80,8 @@ class Request
         'matrix created no jobs'
       elsif compare_url_too_long?
         'compare URL too long; branch/tag names may be too long'
+      elsif request.config.blank?
+        'config is missing or contains YAML syntax error'
       end
     end
 

--- a/spec/travis/model/request/approval_spec.rb
+++ b/spec/travis/model/request/approval_spec.rb
@@ -138,7 +138,6 @@ describe Request::Approval do
 
     it 'returns "github pages branch" if the branch is a github pages branch' do
       request.commit.stubs(:branch).returns('gh-pages')
-      request.stubs(:config).returns('branches' => { 'only' => 'master' })
       approval.message.should == 'github pages branch'
     end
 


### PR DESCRIPTION
I moved the config.blank? condition to the end of the method. It was preventing the other cases to fall first (e.g. github_pages), and therefore it is hard to debug some request issues. 
Found this with @MariadeAnton 