### PR TITLE
Fix PRs being skipped when Github returns a 401/404 for a missing admin

### DIFF
--- a/lib/travis/testing/stubs.rb
+++ b/lib/travis/testing/stubs.rb
@@ -27,8 +27,17 @@ module Travis
             let(:broadcast)           { stub_broadcast           }
             let(:travis_token)        { stub_travis_token        }
             let(:cache)               { stub_cache               }
+            let(:permission)          { stub_permission          }
           end
         end
+      end
+
+      def stub_permission(attributes = {})
+        Stubs.stub 'permission', attributes.reverse_merge(
+          id: 1,
+          user_id: stub_user,
+          repository_id: stub_repo
+        )
       end
 
       def stub_repo(attributes = {})
@@ -60,7 +69,7 @@ module Travis
           github_id: 549743,
           builds_only_with_travis_yml?: false,
           settings: stub_settings,
-          users_with_permission: [],
+          users_with_permission: stub_user,
           default_branch: 'master',
           current_build_id: nil
         )


### PR DESCRIPTION
This PR fixes the problem of missing PR builds, for repos where the admin is not found.

Travis will check for the first 15 users with github tokens and admin rights on the repo. The user permissions' data could be outdated since user permissions are synced with github, only once a day. 
So, the candidate is checked for admin rights again.

The number of candidates is set to be large to reduce the probability of missing a build when the first few candidates aren't valid admins.

An invalid admin's admin permission is revoked, on our side too.

If no admin is found, which could be the case, when a user's admin rights have been revoked recently or their account has been deleted, `Travis::AdminMissing` error is raised. This error is picked up to re-try the build later.
