### PR TITLE
Allow any number of spaces between 'ci' and 'skip'

### DIFF
--- a/lib/travis/commit_command.rb
+++ b/lib/travis/commit_command.rb
@@ -13,7 +13,7 @@ module Travis
     attr_reader :message
 
     def command
-      message =~ /\[ci(?: |:)([\w ]*)\]/i && $1.downcase
+      message =~ /\[ci(?: +|:)([\w ]*)\]/i && $1.downcase
     end
 
     def backwards_skip

--- a/spec/travis/commit_command_spec.rb
+++ b/spec/travis/commit_command_spec.rb
@@ -12,6 +12,11 @@ describe Travis::CommitCommand do
       Travis::CommitCommand.new(message).skip?.should eq true
     end
 
+    it 'is invoked by a commit message containing [ci   skip]' do
+      message = "foo [ci   skip] bar"
+      Travis::CommitCommand.new(message).skip?.should eq true
+    end
+
     it 'is invoked by a commit message containing [CI skip]' do
       message = "foo [CI skip] bar"
       Travis::CommitCommand.new(message).skip?.should eq true
@@ -29,6 +34,11 @@ describe Travis::CommitCommand do
 
     it 'is invoked by the special case: [skip ci]' do
       message = "foo [skip ci] bar"
+      Travis::CommitCommand.new(message).skip?.should eq true
+    end
+
+    it 'is invoked by the special case: [skip     ci]' do
+      message = "foo [skip     ci] bar"
       Travis::CommitCommand.new(message).skip?.should eq true
     end
   end


### PR DESCRIPTION
Since `skip ci` allows it, we should also allow the same for
`ci skip`.

This fixes https://github.com/travis-ci/travis-ci/issues/6121
