### PR TITLE
Remove old email addresses from user data

### DIFF
--- a/lib/travis/github/services/sync_user/user_info.rb
+++ b/lib/travis/github/services/sync_user/user_info.rb
@@ -24,9 +24,7 @@ module Travis
             end
 
             user.update_attributes!(name: name, login: login, gravatar_id: gravatar_id, email: email, education: education)
-            emails = verified_emails
-            emails << email unless emails.include? email
-            emails.each { |e| user.emails.find_or_create_by_email!(e) }
+            update_user_emails
           end
 
           def education
@@ -82,6 +80,13 @@ module Travis
                 end
                 data
               end
+            end
+
+            def update_user_emails
+              github_emails = verified_emails | [email]
+              github_emails.each { |e| user.emails.find_or_create_by_email!(e) }
+              emails_to_remove = user.emails.map(&:email) - github_emails
+              user.emails.where(email: emails_to_remove).destroy_all
             end
         end
       end


### PR DESCRIPTION
This removes the emails that are not present in github anymore from the user data, as requested in https://github.com/travis-ci/travis-ci/issues/3007

I didn’t touch the code that sets `user.email`, though. It still keeps the email even if the email is not present in github anymore, and may even set it to a non-verified email if the `user.email` is not present and that was the only email retrieved: https://github.com/trmcami/travis-core/blob/remove_old_emails/lib/travis/github/services/sync_user/user_info.rb#L49
I wasn't sure about the side effects of clearing `user.email` - should this be updated too?