### PR TITLE
Fix cache UI in Enterprise. 

### DIFF
--- a/lib/travis/services/find_caches.rb
+++ b/lib/travis/services/find_caches.rb
@@ -78,7 +78,7 @@ module Travis
             entries = [entries] unless entries.is_a? Array
             entries.map do |entry|
               next unless config = entry[:s3]
-              service = ::S3::Service.new(config.slice(:secret_access_key, :access_key_id))
+              service = ::S3::Service.new(config.to_h.slice(:secret_access_key, :access_key_id))
               service.buckets.find(config.fetch(:bucket_name))
             end.compact
           end


### PR DESCRIPTION
Schibsted reported an issue where build caching was working but the UI would 500. Tracked this down to a case where the code expected a `Hashr` hash to be recursive when using `.to_h` and the resulting nested `Hashr` hash swallowed the `slice` returning `nil` (since `Hashr` uses `method_missing` to allow you to use methods as hash keys). 

This has come up before with SSL settings. Something to look out for. Also may make sense to do some checking around method names or if args are being passed. Removing the `method_missing` may be too much since that's one of the large things that `Hashr` does. 

It may also be the case that this is or isn't still a problem in master (this is fixing a 2.0 bug). 