### PR TITLE
Update .travis.yml to match ruby versions in master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: ruby
 
 sudo: false
 
-env:
-  - JRUBY_OPTS="--dev -Xcext.enabled=false -Xcompile.invokedynamic=false -J-Xmx1g"
-
 services:
   - redis
+  - memcached
 
 addons:
   postgresql: 9.3
@@ -24,20 +22,13 @@ rvm:
   - "2.0"
   - "2.1"
 
-jdk: oraclejdk7
-
 matrix:
   fast_finish: true
-  allow_failures:
-    - rvm: jruby-head
-    - rvm: jruby-9.0.0.0
 
 before_install:
-  - if [ $TRAVIS_RUBY_VERSION = 'jruby-9.0.0.0' ]; then rvm get head; rvm use --install jruby-9.0.0.0; ruby --version; fi
   - gem install bundler -v 1.9.0
 
 install:
-  # JRuby fails to resolve dependencies on newer bundler
   - bundle _1.9.0_ install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 
 services:
   - redis
-  - memcached
 
 addons:
   postgresql: 9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ cache:
 sudo: false
 
 rvm:
-  - jruby-1.7.16
-  - jruby-head
-  - jruby-9.0.0.0
   - "2.0"
   - "2.1"
 


### PR DESCRIPTION
Been getting some build failures around [JRuby and some utf-8 characters](https://travis-ci.org/travis-ci/travis-core/builds/143346961). [No apps in Enterprise (or at all?) that use `travis-core` also use jruby](https://travisci.slack.com/archives/enterprise/p1468240037003637) so this change is safe and in line with what we're doing in master. 

