### PR TITLE
Enterprise Backport #559: Port ampqs protocol support from travis-config

### DIFF
--- a/lib/travis/config/url.rb
+++ b/lib/travis/config/url.rb
@@ -32,7 +32,6 @@ module Travis
           string.to_s.split('_').collect(&:capitalize).join
         end
       end
-
     end
   end
 end

--- a/lib/travis/config/url.rb
+++ b/lib/travis/config/url.rb
@@ -18,6 +18,7 @@ module Travis
           super.reject { |key, value| key == :database }.merge(vhost: vhost)
         end
       end
+      Amqps = Amqp
 
       class << self
         def parse(url)
@@ -31,6 +32,7 @@ module Travis
           string.to_s.split('_').collect(&:capitalize).join
         end
       end
+
     end
   end
 end

--- a/spec/travis/config_spec.rb
+++ b/spec/travis/config_spec.rb
@@ -122,6 +122,17 @@ describe Travis::Config do
       it { config.amqp.vhost.should == 'vhost' }
     end
 
+    describe 'with a AMQPS RABBITMQ_URL set' do
+      before { ENV['RABBITMQ_URL'] = 'amqps://username:password@host:1234/vhost' }
+      after  { ENV.delete('RABBITMQ_URL') }
+
+      it { config.amqp.username.should == 'username' }
+      it { config.amqp.password.should == 'password' }
+      it { config.amqp.host.should == 'host' }
+      it { config.amqp.port.should == 1234 }
+      it { config.amqp.vhost.should == 'vhost' }
+    end
+
     describe 'with a TRAVIS_REDIS_URL set' do
       before { ENV['TRAVIS_REDIS_URL'] = 'redis://username:password@host:1234' }
       after  { ENV.delete('TRAVIS_REDIS_URL') }


### PR DESCRIPTION
Backport of #559 to the `te-dev` branch. 