### PR TITLE
Talk to the Sync 2.0 queue

### DIFF
--- a/lib/travis/services/sync_user.rb
+++ b/lib/travis/services/sync_user.rb
@@ -12,7 +12,11 @@ module Travis
 
       def trigger_sync
         logger.info("Synchronizing via Sidekiq for user: #{user.login}")
-        Travis::Sidekiq::SynchronizeUser.perform_async(user.id)
+        ::Sidekiq::Client.push(
+          'queue' => 'sync',
+          'class' => 'Travis::GithubSync::Worker',
+          'args'  => [:sync_user, user_id: user.id]
+        )
         user.update_column(:is_syncing, true)
         true
       end

--- a/spec/travis/services/sync_user_spec.rb
+++ b/spec/travis/services/sync_user_spec.rb
@@ -13,7 +13,11 @@ describe Travis::Services::SyncUser do
     end
 
     it 'enqueues a sync job' do
-      Travis::Sidekiq::SynchronizeUser.expects(:perform_async).with(user.id)
+      ::Sidekiq::Client.expects(:push).with(
+        'queue' => 'sync',
+        'class' => 'Travis::GithubSync::Worker',
+        'args'  => [:sync_user, user_id: user.id]
+      )
       service.run
     end
 


### PR DESCRIPTION
Sync 2.0 now uses the queue `sync` (was: `user_sync`). It currently still polls on the old queue names and has a backwards compatibility class so API still works.

Admin should push to the new queue `sync`, and use the class name `Travis::GithubSync::Worker`.

Like so:

```ruby
  Sidekiq::Client.push(
    'queue' => 'sync',
    'class' => 'Travis::GithubSync::Worker',
    'args'  => [user_id: id]
  )
```