### PR TITLE
Remove conditional around pusher-live as that is now the default.

### DIFF
--- a/lib/travis/addons/pusher/event_handler.rb
+++ b/lib/travis/addons/pusher/event_handler.rb
@@ -34,12 +34,7 @@ module Travis
           end
 
           def queue
-            if Travis::Features.enabled_for_all?(:"pusher-live") ||
-               Travis::Features.repository_active?(:"pusher-live", repository_id)
-              :"pusher-live"
-            else
-              :pusher
-            end
+            :"pusher-live"
           end
 
           def repository_id


### PR DESCRIPTION
An Enterprise customer noticed that on the latest version of Travis Enterprise the `pusher` sidekiq queue was growing but not being worked. The short term solution for 2.0 was to have `travis-live` work both queues. The long term fix is to retire the feature flag around `pusher-live` since it's been fully rolled out and we don't use Feature flags in Enterprise
