### PR TITLE
[Enterprise] Put a conditional around net-http-persistent since it doesn't work for Ruby 2.0 in Enterprise 2.0

### DIFF
--- a/travis-core.gemspec
+++ b/travis-core.gemspec
@@ -45,4 +45,7 @@ Gem::Specification.new do |s|
   s.add_dependency 's3',                '~> 0.3'
   s.add_dependency 'gh'
   s.add_dependency 'multi_json'
+
+  # fix building in 2.0
+  s.add_dependency "net-http-persistent",   "~> 2.9" if RUBY_VERSION < "2.1"
 end


### PR DESCRIPTION
When needing to patch `travis-core` in Enterprise 2.0 it won't build because of `net-http-persistent` doesn't build in 2.0 unless pinned to a version. So this does that. 

`travis-core` is deprecated so this shouldn't be needed too much longer but reduce headaches for when we do need to patch `travis-core` (like today). 