### PR TITLE
Add conditional for library that wont build on Ruby 2.0

### DIFF
--- a/travis-core.gemspec
+++ b/travis-core.gemspec
@@ -46,4 +46,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'gh'
   s.add_dependency 'multi_json'
   s.add_dependency 'google-api-client', '~> 0.9.4'
+
+  # Needed for Ruby 2.0 builds
+  s.add_dependency "net-http-persistent",   "~> 2.9" if RUBY_VERSION < "2.1"
 end


### PR DESCRIPTION
Already did this in the `enterprise-2.0` branch but realized I should have done it first in master and ported it back instead so things like https://github.com/travis-ci/travis-core/pull/563 can make it into master in case we need another round of `travis-core` in Enterprise. 