### PR TITLE
Backport "Replace entire secure env var with [secure]" from Travis API

### DIFF
--- a/lib/travis/model/env_helpers.rb
+++ b/lib/travis/model/env_helpers.rb
@@ -3,7 +3,11 @@ module Travis::Model::EnvHelpers
     vars = [vars] unless vars.is_a?(Array)
     vars.compact.map do |var|
       repository.key.secure.decrypt(var) do |decrypted|
-        Travis::Helpers.obfuscate_env_vars(decrypted)
+       if decrypted.include?('=')
+          "#{decrypted.to_s.split('=').first}=[secure]"
+        else
+          '[secure]'
+        end
       end
     end
   end

--- a/spec/travis/model/job_spec.rb
+++ b/spec/travis/model/job_spec.rb
@@ -88,17 +88,18 @@ describe Job do
       }
     end
 
-    it 'obfuscates env vars' do
+   it 'obfuscates env vars, including accidents' do
       job = Job.new(repository: Factory(:repository))
+      secure = job.repository.key.secure
       job.expects(:secure_env_enabled?).at_least_once.returns(true)
       config = { rvm: '1.8.7',
-                 env: [job.repository.key.secure.encrypt('BAR=barbaz'), 'FOO=foo']
+                 env: [secure.encrypt('BAR=barbaz'), secure.encrypt('PROBLEM'), 'FOO=foo']
                }
       job.config = config
 
       job.obfuscated_config.should == {
         rvm: '1.8.7',
-        env: 'BAR=[secure] FOO=foo'
+        env: 'BAR=[secure] [secure] FOO=foo'
       }
     end
 


### PR DESCRIPTION
This backports https://github.com/travis-ci/travis-api/pull/335 for `enterprise-2.0` since `travis-core`

/cc @joecorcoran 